### PR TITLE
Repo URL changed to github.com/redhat-best-practices-for-k8s/certsuite-operator

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -9,7 +9,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: cnf-certsuite-operator
-repo: github.com/test-network-function/cnf-certsuite-operator
+repo: github.com/redhat-best-practices-for-k8s/certsuite-operator
 resources:
 - api:
     crdVersion: v1
@@ -18,7 +18,7 @@ resources:
   domain: redhat.com
   group: cnf-certifications
   kind: CnfCertificationSuiteRun
-  path: github.com/test-network-function/cnf-certsuite-operator/api/v1alpha1
+  path: github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1
   version: v1alpha1
   webhooks:
     validation: true

--- a/bundle/manifests/cnf-certsuite-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cnf-certsuite-operator.clusterserviceversion.yaml
@@ -308,7 +308,7 @@ spec:
   - telco
   links:
   - name: CNF Certification Suite Operator
-    url: https://github.com/test-network-function/cnf-certsuite-operator
+    url: https://github.com/redhat-best-practices-for-k8s/certsuite-operator
   maturity: alpha
   provider:
     name: Red Hat

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,8 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	consolev1 "github.com/openshift/api/console/v1"
-	cnfcertificationsv1alpha1 "github.com/test-network-function/cnf-certsuite-operator/api/v1alpha1"
-	"github.com/test-network-function/cnf-certsuite-operator/internal/controller"
+	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
+	"github.com/redhat-best-practices-for-k8s/certsuite-operator/internal/controller"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	//+kubebuilder:scaffold:imports
 )

--- a/cnf-cert-sidecar/app/cnf-cert-suite-report/cnfcertsuitereport.go
+++ b/cnf-cert-sidecar/app/cnf-cert-suite-report/cnfcertsuitereport.go
@@ -3,9 +3,9 @@ package cnfcertsuitereport
 import (
 	"encoding/json"
 
-	"github.com/sirupsen/logrus"
 	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
 	"github.com/redhat-best-practices-for-k8s/certsuite-operator/cnf-cert-sidecar/app/claim"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/cnf-cert-sidecar/app/cnf-cert-suite-report/cnfcertsuitereport.go
+++ b/cnf-cert-sidecar/app/cnf-cert-suite-report/cnfcertsuitereport.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 
 	"github.com/sirupsen/logrus"
-	cnfcertificationsv1alpha1 "github.com/test-network-function/cnf-certsuite-operator/api/v1alpha1"
-	"github.com/test-network-function/cnf-certsuite-operator/cnf-cert-sidecar/app/claim"
+	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
+	"github.com/redhat-best-practices-for-k8s/certsuite-operator/cnf-cert-sidecar/app/claim"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/cnf-cert-sidecar/app/main.go
+++ b/cnf-cert-sidecar/app/main.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	cnfcertificationsv1alpha1 "github.com/test-network-function/cnf-certsuite-operator/api/v1alpha1"
-	"github.com/test-network-function/cnf-certsuite-operator/cnf-cert-sidecar/app/claim"
-	cnfcertsuitereport "github.com/test-network-function/cnf-certsuite-operator/cnf-cert-sidecar/app/cnf-cert-suite-report"
+	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
+	"github.com/redhat-best-practices-for-k8s/certsuite-operator/cnf-cert-sidecar/app/claim"
+	cnfcertsuitereport "github.com/redhat-best-practices-for-k8s/certsuite-operator/cnf-cert-sidecar/app/cnf-cert-suite-report"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"

--- a/cnf-cert-sidecar/app/main.go
+++ b/cnf-cert-sidecar/app/main.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
 	"github.com/redhat-best-practices-for-k8s/certsuite-operator/cnf-cert-sidecar/app/claim"
 	cnfcertsuitereport "github.com/redhat-best-practices-for-k8s/certsuite-operator/cnf-cert-sidecar/app/cnf-cert-suite-report"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"

--- a/config/manifests/bases/cnf-certsuite-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cnf-certsuite-operator.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ spec:
   - telco
   links:
   - name: CNF Certification Suite Operator
-    url: https://github.com/test-network-function/cnf-certsuite-operator
+    url: https://github.com/redhat-best-practices-for-k8s/certsuite-operator
   maturity: alpha
   provider:
     name: Red Hat

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/test-network-function/cnf-certsuite-operator
+module github.com/redhat-best-practices-for-k8s/certsuite-operator
 
 go 1.22.5
 

--- a/internal/controller/cnf-cert-job/cnfcertjob.go
+++ b/internal/controller/cnf-cert-job/cnfcertjob.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/test-network-function/cnf-certsuite-operator/internal/controller/definitions"
+	"github.com/redhat-best-practices-for-k8s/certsuite-operator/internal/controller/definitions"
 )
 
 const (

--- a/internal/controller/cnfcertificationsuiterun_controller.go
+++ b/internal/controller/cnfcertificationsuiterun_controller.go
@@ -36,10 +36,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	cnfcertificationsv1alpha1 "github.com/test-network-function/cnf-certsuite-operator/api/v1alpha1"
-	cnfcertjob "github.com/test-network-function/cnf-certsuite-operator/internal/controller/cnf-cert-job"
-	"github.com/test-network-function/cnf-certsuite-operator/internal/controller/definitions"
-	controllerlogger "github.com/test-network-function/cnf-certsuite-operator/internal/controller/logger"
+	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
+	cnfcertjob "github.com/redhat-best-practices-for-k8s/certsuite-operator/internal/controller/cnf-cert-job"
+	"github.com/redhat-best-practices-for-k8s/certsuite-operator/internal/controller/definitions"
+	controllerlogger "github.com/redhat-best-practices-for-k8s/certsuite-operator/internal/controller/logger"
 )
 
 var sideCarImage string

--- a/internal/controller/cnfcertificationsuiterun_controller_ginkgo_test.go
+++ b/internal/controller/cnfcertificationsuiterun_controller_ginkgo_test.go
@@ -27,7 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cnfcertificationsv1alpha1 "github.com/test-network-function/cnf-certsuite-operator/api/v1alpha1"
+	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
 )
 
 var _ = Describe("CnfCertificationSuiteRun Controller", func() {

--- a/internal/controller/cnfcertificationsuiterun_controller_test.go
+++ b/internal/controller/cnfcertificationsuiterun_controller_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	cnfcertificationsv1alpha1 "github.com/test-network-function/cnf-certsuite-operator/api/v1alpha1"
-	"github.com/test-network-function/cnf-certsuite-operator/internal/controller/definitions"
+	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
+	"github.com/redhat-best-practices-for-k8s/certsuite-operator/internal/controller/definitions"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/controller/cnfcertificationsuiterun_controller_test.go
+++ b/internal/controller/cnfcertificationsuiterun_controller_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
 	"github.com/redhat-best-practices-for-k8s/certsuite-operator/internal/controller/definitions"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -32,7 +32,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	cnfcertificationsv1alpha1 "github.com/test-network-function/cnf-certsuite-operator/api/v1alpha1"
+	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
 	. "github.com/onsi/gomega"    //nolint:revive
 
-	"github.com/test-network-function/cnf-certsuite-operator/test/utils"
+	"github.com/redhat-best-practices-for-k8s/certsuite-operator/test/utils"
 )
 
 const namespace = "cnf-certsuite-operator-system"


### PR DESCRIPTION
URL replacement only. The docker images are still pushed and pulled frrom the old (quay) testnetworkfunction account. That will be changed in the next PR.