### PR TITLE
Quay repos changed to quay.io/redhat-best-practices-for-k8s/certsuite-operator

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,8 @@ on:
 
 env:
   REGISTRY: quay.io
-  REGISTRY_USER: testnetworkfunction
-  REPO_BASE_NAME: cnf-certsuite-operator
+  REGISTRY_USER: redhat-best-practices-for-k8s
+  REPO_BASE_NAME: certsuite-operator
 
   TERM: xterm-color
 

--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ deploy-samples: kustomize ## Deploy the sample CR, configmap and secret in the c
 # Install the operator using OLM subscription. It will create the namespace ${OLM_INSTALL_NAMESPACE}, which
 # is defaulted to "cnf-certsuite-operator" if not set, and deploys the CatalogSource, OperatorGroup and
 # and the subscription, using the operator found in the "alpha" channel of the catalog ${OLM_INSTALL_IMG_CATALOG}.
-OLM_INSTALL_IMG_CATALOG ?= quay.io/testnetworkfunction/cnf-certsuite-operator-catalog:latest
+OLM_INSTALL_IMG_CATALOG ?= quay.io/redhat-best-practices-for-k8s/certsuite-operator-catalog:latest
 OLM_INSTALL_NAMESPACE ?= cnf-certsuite-operator
 .PHONY: olm-install
 olm-install: kustomize ## Installs the operator using OLM subscription.

--- a/bundle/manifests/cnf-certsuite-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cnf-certsuite-operator.clusterserviceversion.yaml
@@ -124,12 +124,12 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: SIDECAR_APP_IMG
-                  value: quay.io/testnetworkfunction/cnf-certsuite-operator-sidecar:v0.0.1
+                  value: quay.io/redhat-best-practices-for-k8s/certsuite-operator-sidecar:v0.0.1
                 - name: CONTROLLER_NS
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/testnetworkfunction/cnf-certsuite-operator:v0.0.1
+                image: quay.io/redhat-best-practices-for-k8s/certsuite-operator:v0.0.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,11 +4,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/testnetworkfunction/cnf-certsuite-operator
+  newName: quay.io/redhat-best-practices-for-k8s/certsuite-operator
   newTag: v0.0.1
 patches:
 - patch: '[{"op": "replace", "path": "/spec/template/spec/containers/0/env/1", "value":
-    {"name": "SIDECAR_APP_IMG", "value": "quay.io/testnetworkfunction/cnf-certsuite-operator-sidecar:v0.0.1"}
+    {"name": "SIDECAR_APP_IMG", "value": "quay.io/redhat-best-practices-for-k8s/certsuite-operator-sidecar:v0.0.1"}
     }]'
   target:
     kind: Deployment

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: SIDECAR_APP_IMG
-          value: quay.io/testnetworkfunction/cnf-certsuite-operator-sidecar:v0.0.1
+          value: quay.io/redhat-best-practices-for-k8s/certsuite-operator-sidecar:v0.0.1
         - name: CONTROLLER_NS
           valueFrom:
             fieldRef:

--- a/config/samples/olm/catalogsource.yaml
+++ b/config/samples/olm/catalogsource.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: cnf-certsuite-operator
 spec:
   sourceType: grpc
-  image: quay.io/testnetworkfunction/cnf-certsuite-operator-catalog:v0.0.1
+  image: quay.io/redhat-best-practices-for-k8s/certsuite-operator-catalog:v0.0.1
   displayName: CNF Certification Suite OLM Test Catalog
   publisher: RedHat.com
   grpcPodConfig:


### PR DESCRIPTION
Quay robot user+token has already been updated in repo's settings.