### PR TITLE
Operator renamed and removed some cnf- prefixes

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -8,7 +8,7 @@ layout:
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
-projectName: redhat-best-practices-for-k8s-certsuite-operator
+projectName: rh-best-practices-for-k8s-certsuite-operator
 repo: github.com/redhat-best-practices-for-k8s/certsuite-operator
 resources:
 - api:

--- a/PROJECT
+++ b/PROJECT
@@ -8,7 +8,7 @@ layout:
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
-projectName: cnf-certsuite-operator
+projectName: redhat-best-practices-for-k8s-certsuite-operator
 repo: github.com/redhat-best-practices-for-k8s/certsuite-operator
 resources:
 - api:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CNF Certification Suite Operator
+# Certification Suite Operator
 
 [![red hat](https://img.shields.io/badge/red%20hat---?color=gray&logo=redhat&logoColor=red&style=flat)](https://www.redhat.com)
 [![openshift](https://img.shields.io/badge/openshift---?color=gray&logo=redhatopenshift&logoColor=red&style=flat)](https://www.redhat.com/en/technologies/cloud-computing/openshift)
@@ -6,9 +6,9 @@
 ## Description
 
 Kubernetes/Openshift Operator (scaffolded with operator-sdk) running the
-[CNF Certification Suite Container](https://github.com/test-network-function/cnf-certification-test).
+[Certification Suite Container](https://github.com/redhat-best-practices-for-k8s/certsuite-operator).
 
-The CNF Certification Suites provide a set of test cases for the
+The Certification Suites provide a set of test cases for the
 Containerized Network Functions/Cloud Native Functions (CNFs) to verify if
 best practices for deployment on Red Hat OpenShift clusters are followed.
 
@@ -16,12 +16,12 @@ best practices for deployment on Red Hat OpenShift clusters are followed.
 
 The Operator registers a CRD in the cluster: `CnfCertificationSuiteRun`.
 
-In order to fire up the CNF Certification Suite, the user must create
+In order to fire up the Certification Suite, the user must create
 a CnfCertificationSuiteRun CR, also informally referred as Run CR, which
 has to be created with a Config Map containing the cnf certification suites configuration,
 and a Secret containing the preflight suite credentials.
 **Note:** All resources mentioned above should be created in the operator's
-installation namespace (by default `cnf-certsuite-operator`)
+installation namespace (by default `certsuite-operator`)
 
 See resources relationship diagram:
 
@@ -31,7 +31,7 @@ When the CR is deployed, a new pod with two containers is created:
 
 1. Container built with the cnf certification image in order to run the suites.
 2. Container (sidecar) which updates the Run CR's status fields containing the
-CNF Certification suites results based on results claim file created by the
+Certification suites results based on results claim file created by the
 previous container.
 
 **See diagram summarizing the process:**
@@ -53,7 +53,7 @@ kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 Clone Cnf Certification Operator repo:
 
 ```sh
-git clone https://github.com/test-network-function/cnf-certsuite-operator.git
+git clone https://github.com/redhat-best-practices-for-k8s/certsuite-operator.git
 ```
 
 #### Option 1: Using OLM subscription
@@ -61,7 +61,7 @@ git clone https://github.com/test-network-function/cnf-certsuite-operator.git
 1. Export OLM catalog image and namespace:
 
     ```sh
-    export OLM_INSTALL_IMG_CATALOG=<your-registry.com>/<your-repo>/cnf-certsuite-operator-catalog:<version>
+    export OLM_INSTALL_IMG_CATALOG=<your-registry.com>/<your-repo>/certsuite-operator-catalog:<version>
     export OLM_INSTALL_NAMESPACE=<your-namespace>
     ```
 
@@ -69,8 +69,8 @@ git clone https://github.com/test-network-function/cnf-certsuite-operator.git
     they will be set by default to:
 
     ```sh
-    OLM_INSTALL_IMG_CATALOG = quay.io/testnetworkfunction/cnf-certsuite-operator-catalog:latest
-    OLM_INSTALL_NAMESPACE = cnf-certsuite-operator
+    OLM_INSTALL_IMG_CATALOG = quay.io/redhat-best-practices-for-k8s/certsuite-operator-catalog:latest
+    OLM_INSTALL_NAMESPACE = certsuite-operator
     ```
 
 2. Install Cnf Certification Operator:\
@@ -89,12 +89,12 @@ git clone https://github.com/test-network-function/cnf-certsuite-operator.git
     NAME                                                              READY   STATUS      RESTARTS   AGE
     afa1738b451274ef681c19ae8e8a6dcc50f65568056ef97355a4a2fe14hbhpn   0/1     Completed   0          3m32s
     cnf-certsuite-controller-manager-67f68cd4cb-625ww                 2/2     Running     0          3m18s
-    cnf-certsuite-operator-olm-catalog-mkmqw                          1/1     Running     0          3m45s
+    certsuite-operator-olm-catalog-mkmqw                          1/1     Running     0          3m45s
     ```
     <!-- markdownlint-enable -->
 
     **Note:** If `OLM_INSTALL_NAMESPACE` environment variable wasn't exported
-    in previous steps, use `cnf-certsuite-operator` as namespace instead.
+    in previous steps, use `certsuite-operator` as namespace instead.
 
 #### Option 2: Manually building and deploying the operator
 
@@ -110,8 +110,8 @@ kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/downlo
 1. Export images environment variables:
 
     ```sh
-    export IMG=<your-registry.com>/<your-repo>/cnf-certsuite-operator:<version>
-    export SIDECAR_IMG=<your-registry.com>/<your-repo>/cnf-certsuite-operator-sidecar:<version>
+    export IMG=<your-registry.com>/<your-repo>/certsuite-operator:<version>
+    export SIDECAR_IMG=<your-registry.com>/<your-repo>/certsuite-operator-sidecar:<version>
     ```
 
 2. Build and upload the controller image to your registry account:
@@ -139,7 +139,7 @@ kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/downlo
 1. Export images environment variables (optional):
 
     ```sh
-    export IMG=<your-cnf-certsuite-operator-image-name>
+    export IMG=<your-certsuite-operator-image-name>
     export SIDECAR_IMG=<your-sidecar-app-image-name>
     ```
 
@@ -172,10 +172,10 @@ make deploy-samples
 ```
 
 **Note**: Current sample CnfCertificationSuiteRun CR configures
-the CNF Certification Suite to run the "observability" test suite only.
-It can be modified by changing manually the `labelsFilter` of the [sample CR](https://github.com/test-network-function/cnf-certsuite-operator/blob/main/config/samples/cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml).
+the Certification Suite to run the "observability" test suite only.
+It can be modified by changing manually the `labelsFilter` of the [sample CR](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/blob/main/config/samples/cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml).
 
-### How to customize the CNF Certification Suite run
+### How to customize the Certification Suite run
 
 1. Create Resources
 
@@ -185,12 +185,12 @@ It can be modified by changing manually the `labelsFilter` of the [sample CR](ht
     1. Config map:\
     Containing the cnf certification configuration file
     content under the `tnf_config.yaml` key.\
-    (see [CNF Certification configuration description](https://test-network-function.github.io/cnf-certification-test/configuration/))
+    (see [Certification configuration description](https://redhat-best-practices-for-k8s.github.io/certsuite-operator/configuration/))
 
     2. Secret:\
     Containing cnf preflight suite credentials
     under the `preflight_dockerconfig.json` key.\
-    (see [Preflight Integration description](https://test-network-function.github.io/cnf-certification-test/runtime-env/#disable-intrusive-tests))
+    (see [Preflight Integration description](https://redhat-best-practices-for-k8s.github.io/certsuite-operator/runtime-env/#disable-intrusive-tests))
 
     3. CnfCertificationSuiteRun CR:\
     Containing the following Spec fields that has to be filled in:
@@ -205,7 +205,7 @@ It can be modified by changing manually the `labelsFilter` of the [sample CR](ht
         or "false" otherwise.\
         **Note:** When setting this field to true, the claim file will be sent to
         a server external to the cluster. see
-        [collector repository](https://github.com/test-network-function/collector)
+        [collector repository](https://github.com/redhat-best-practices-for-k8s/collector)
         for more details
         - **showAllResultsLogs**: Set to "true" to show all result's logs,
         and not only logs of failed test cases.
@@ -214,7 +214,7 @@ It can be modified by changing manually the `labelsFilter` of the [sample CR](ht
         resources of all results. and not only compliant and non-compliant
         resources of failed test cases. This field is set to "false" by default.
 
-        See a [sample CnfCertificationSuiteRun CR](https://github.com/test-network-function/cnf-certsuite-operator/blob/main/config/samples/cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml)
+        See a [sample CnfCertificationSuiteRun CR](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/blob/main/config/samples/cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml)
 
 2. Apply resources into the cluster
 
@@ -233,12 +233,12 @@ It can be modified by changing manually the `labelsFilter` of the [sample CR](ht
 ### Review results
 
 If all of the resources were applied successfully, the cnf certification suites
-will run on a new created `pod` in the `cnf-certsuite-operator` namespace.
+will run on a new created `pod` in the `certsuite-operator` namespace.
 The pod has the name with the form `cnf-job-run-N`:
 
 <!-- markdownlint-disable -->
 ```sh
-$ oc get pods -n cnf-certsuite-operator 
+$ oc get pods -n certsuite-operator 
 NAME                                                READY   STATUS      RESTARTS   AGE
 cnf-certsuite-controller-manager-6c6bb6d965-jslmd   2/2     Running     0          21h
 cnf-job-run-1                                       0/2     Completed   0          21h
@@ -250,12 +250,12 @@ by checking CnfCertificationSuiteRun CR's status.
 In the successful case, expect to see the following status:
 
 ```sh
-$ oc get cnfcertificationsuiteruns.cnf-certifications.redhat.com -n cnf-certsuite-operator
+$ oc get cnfcertificationsuiteruns.cnf-certifications.redhat.com -n certsuite-operator
 NAME                              AGE   STATUS
 cnfcertificationsuiterun-sample   50m   CertSuiteFinished
 ```
 
-The status `CertSuiteFinished` means the CNF Cert Suite pod has finished running
+The status `CertSuiteFinished` means the Cert Suite pod has finished running
 all the test cases, so the results can be inspected in field `report` of the Run
 CR's (cnfcertificationsuiterun-sample) status subresource.
 
@@ -294,14 +294,14 @@ If the the result is "skipped" or "failed" contains also the skip\failure reason
     <!-- markdownlint-enable -->
 
 - Summary: Summarize the total number of tests by their results.
-- Verdict: Specifies the overall result of the CNF certificattion suites run.\
+- Verdict: Specifies the overall result of the certificattion suites run.\
 Poissible verdicts: "pass", "skip", "fail", "error".
 
 Run the following command to ensure its creation:
 
 <!-- markdownlint-disable -->
 ```sh
-$ oc get cnfcertificationsuiteruns.cnf-certifications.redhat.com -n cnf-certsuite-operator cnfcertificationsuiterun-sample -o json | jq '.status.report.verdict'
+$ oc get cnfcertificationsuiteruns.cnf-certifications.redhat.com -n certsuite-operator cnfcertificationsuiterun-sample -o json | jq '.status.report.verdict'
 "pass"
 ```
 <!-- markdownlint-enable -->

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -4,7 +4,7 @@ FROM scratch
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=redhat-best-practices-for-k8s-certsuite-operator
+LABEL operators.operatorframework.io.bundle.package.v1=rh-best-practices-for-k8s-certsuite-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -4,7 +4,7 @@ FROM scratch
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=cnf-certsuite-operator
+LABEL operators.operatorframework.io.bundle.package.v1=redhat-best-practices-for-k8s-certsuite-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1

--- a/bundle/manifests/certsuite-config_v1_configmap.yaml
+++ b/bundle/manifests/certsuite-config_v1_configmap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+data:
+  tnf_config.yaml: |
+    targetNameSpaces:
+      - name: tnf
+    podsUnderTestLabels:
+      - "redhat-best-practices-for-k8s.com/generic: target"
+    # deprecated operator label ("test-network-function.com/operator:"") still configured by default, no need to add it here
+    operatorsUnderTestLabels:
+      - "redhat-best-practices-for-k8s.com/operator:target"
+      - "redhat-best-practices-for-k8s.com/operator1:new"
+      - "cnf/test:cr-scale-operator"
+    targetCrdFilters:
+      - nameSuffix: "group1.test.com"
+        scalable: false
+      - nameSuffix: "redhat-best-practices-for-k8s.com"
+        scalable: false
+      - nameSuffix: "memcacheds.cache.example.com"
+        scalable: true
+    managedDeployments:
+      - name: jack
+    managedStatefulsets:
+      - name: jack
+    certifiedcontainerinfo:
+      - name: rocketchat/rocketchat
+        repository: registry.connect.redhat.com
+        tag: 0.56.0-1 # optional, "latest" assumed if empty
+        digest: # if set, takes precedence over tag. e.g. "sha256:aa34453a6417f8f76423ffd2cf874e9c4a1a5451ac872b78dc636ab54a0ebbc3"
+      - name: rocketchat/rocketchat
+        repository: registry.connect.redhat.com
+        tag: 0.56.0-1
+        digest: sha256:03f7f2499233a302351821d6f78f0e813c3f749258184f4133144558097c57b0
+    checkDiscoveredContainerCertificationStatus: false
+    acceptedKernelTaints:
+      - module: vboxsf
+      - module: vboxguest
+    skipScalingTestDeployments:
+      - name: deployment1
+        namespace: tnf
+    skipScalingTestStatefulsets:
+      - name: statefulset1
+        namespace: tnf
+    skipHelmChartList:
+      - name: coredns
+    validProtocolNames:
+      - "http3"
+      - "sctp"
+    servicesignorelist:
+      - "hazelcast-platform-controller-manager-service"
+      - "hazelcast-platform-webhook-service"
+      - "new-pro-controller-manager-metrics-service"
+    executedBy: ""
+    partnerName: ""
+    collectorAppPassword: ""
+kind: ConfigMap
+metadata:
+  name: certsuite-config

--- a/bundle/manifests/certsuite-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/certsuite-controller-manager-metrics-service_v1_service.yaml
@@ -4,13 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     control-plane: controller-manager
-  name: cnf-certsuite-controller-manager-metrics-service
+  name: certsuite-controller-manager-metrics-service
 spec:
   ports:
   - name: https

--- a/bundle/manifests/certsuite-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/certsuite-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,12 +4,12 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: cnf-certsuite-operator
-  name: cnf-certsuite-metrics-reader
+    app.kubernetes.io/part-of: certsuite-operator
+  name: certsuite-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics

--- a/bundle/manifests/certsuite-preflight-dockerconfig_v1_secret.yaml
+++ b/bundle/manifests/certsuite-preflight-dockerconfig_v1_secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  preflight_dockerconfig.json: |
+    eyAiYXV0aHMiOiB7fSB9Cg==
+kind: Secret
+metadata:
+  name: certsuite-preflight-dockerconfig
+type: Opaque

--- a/bundle/manifests/certsuite-webhook-service_v1_service.yaml
+++ b/bundle/manifests/certsuite-webhook-service_v1_service.yaml
@@ -4,12 +4,12 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
     app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: cnf-certsuite-operator
-  name: cnf-certsuite-webhook-service
+    app.kubernetes.io/part-of: certsuite-operator
+  name: certsuite-webhook-service
 spec:
   ports:
   - port: 443

--- a/bundle/manifests/redhat-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/redhat-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
@@ -9,21 +9,21 @@ metadata:
           "kind": "CnfCertificationSuiteRun",
           "metadata": {
             "labels": {
-              "app.kubernetes.io/created-by": "cnf-certsuite-operator",
+              "app.kubernetes.io/created-by": "certsuite-operator",
               "app.kubernetes.io/instance": "cnfcertificationsuiterun-sample",
               "app.kubernetes.io/managed-by": "kustomize",
               "app.kubernetes.io/name": "cnfcertificationsuiterun",
-              "app.kubernetes.io/part-of": "cnf-certsuite-operator"
+              "app.kubernetes.io/part-of": "certsuite-operator"
             },
             "name": "cnfcertificationsuiterun-sample",
-            "namespace": "cnf-certsuite-operator"
+            "namespace": "certsuite-operator"
           },
           "spec": {
-            "configMapName": "cnf-certsuite-config",
+            "configMapName": "certsuite-config",
             "enableDataCollection": false,
-            "labelsFilter": "access-control",
+            "labelsFilter": "observability",
             "logLevel": "info",
-            "preflightSecretName": "cnf-certsuite-preflight-dockerconfig",
+            "preflightSecretName": "certsuite-preflight-dockerconfig",
             "showAllResultsLogs": false,
             "showCompliantResourcesAlways": false,
             "timeout": "2h"
@@ -31,11 +31,11 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    console.openshift.io/plugins: '["cnf-certsuite-plugin"]'
-    createdAt: "2024-07-01T07:39:14Z"
+    console.openshift.io/plugins: '["certsuite-plugin"]'
+    createdAt: "2024-08-09T12:07:19Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: cnf-certsuite-operator.v0.0.1
+  name: redhat-best-practices-for-k8s-certsuite-operator.v0.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -47,9 +47,9 @@ spec:
       kind: CnfCertificationSuiteRun
       name: cnfcertificationsuiteruns.cnf-certifications.redhat.com
       version: v1alpha1
-  description: Deploys the CNF Certification Suite Pod to run the certification suite
-    on target CNF resources.
-  displayName: CNF Certification Suite Operator
+  description: Deploys Red Hat's Best Practices for Kubernetes Certification Suite
+    Pod to run the Certification Test Suite on target resources.
+  displayName: Red Hat's Best Practices for Kubernetes Certification Suite Operator
   icon:
   - base64data: ""
     mediatype: ""
@@ -67,7 +67,7 @@ spec:
           - '*'
           verbs:
           - '*'
-        serviceAccountName: cnf-certsuite-cluster-access
+        serviceAccountName: certsuite-cluster-access
       - rules:
         - apiGroups:
           - console.openshift.io
@@ -87,17 +87,17 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: cnf-certsuite-controller-manager
+        serviceAccountName: certsuite-controller-manager
       deployments:
       - label:
           app.kubernetes.io/component: manager
-          app.kubernetes.io/created-by: cnf-certsuite-operator
+          app.kubernetes.io/created-by: certsuite-operator
           app.kubernetes.io/instance: controller-manager
           app.kubernetes.io/managed-by: kustomize
           app.kubernetes.io/name: deployment
-          app.kubernetes.io/part-of: cnf-certsuite-operator
+          app.kubernetes.io/part-of: certsuite-operator
           control-plane: controller-manager
-        name: cnf-certsuite-controller-manager
+        name: certsuite-controller-manager
         spec:
           replicas: 1
           selector:
@@ -189,7 +189,7 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
-              serviceAccountName: cnf-certsuite-controller-manager
+              serviceAccountName: certsuite-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:
               - name: cert
@@ -290,7 +290,7 @@ spec:
           - get
           - patch
           - update
-        serviceAccountName: cnf-certsuite-controller-manager
+        serviceAccountName: certsuite-controller-manager
     strategy: deployment
   installModes:
   - supported: true
@@ -307,7 +307,7 @@ spec:
   - cloud
   - telco
   links:
-  - name: CNF Certification Suite Operator
+  - name: Red Hat's Best Practices for Kubernetes Certification Suite Operator
     url: https://github.com/redhat-best-practices-for-k8s/certsuite-operator
   maturity: alpha
   provider:
@@ -317,7 +317,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: cnf-certsuite-controller-manager
+    deploymentName: certsuite-controller-manager
     failurePolicy: Fail
     generateName: vcnfcertificationsuiterun.kb.io
     rules:

--- a/bundle/manifests/rh-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rh-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     createdAt: "2024-08-09T12:07:19Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: redhat-best-practices-for-k8s-certsuite-operator.v0.0.1
+  name: rh-best-practices-for-k8s-certsuite-operator.v0.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -3,7 +3,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: redhat-best-practices-for-k8s-certsuite-operator
+  operators.operatorframework.io.bundle.package.v1: rh-best-practices-for-k8s-certsuite-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -3,7 +3,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: cnf-certsuite-operator
+  operators.operatorframework.io.bundle.package.v1: redhat-best-practices-for-k8s-certsuite-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: certificate
     app.kubernetes.io/instance: serving-cert
     app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: selfsigned-issuer
   namespace: system
@@ -23,8 +23,8 @@ metadata:
     app.kubernetes.io/name: certificate
     app.kubernetes.io/instance: serving-cert
     app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: cnf-certsuite-operator
+namespace: certsuite-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: cnf-certsuite-
+namePrefix: certsuite-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/default/manual-deploy/kustomization.yaml
+++ b/config/default/manual-deploy/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: cnf-certsuite-operator
+namespace: certsuite-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: cnf-certsuite-
+namePrefix: certsuite-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/default/manual-deploy/webhookcainjection_patch.yaml
+++ b/config/default/manual-deploy/webhookcainjection_patch.yaml
@@ -7,8 +7,8 @@
 #     app.kubernetes.io/name: mutatingwebhookconfiguration
 #     app.kubernetes.io/instance: mutating-webhook-configuration
 #     app.kubernetes.io/component: webhook
-#     app.kubernetes.io/created-by: cnf-certsuite-operator
-#     app.kubernetes.io/part-of: cnf-certsuite-operator
+#     app.kubernetes.io/created-by: certsuite-operator
+#     app.kubernetes.io/part-of: certsuite-operator
 #     app.kubernetes.io/managed-by: kustomize
 #   name: mutating-webhook-configuration
 #   annotations:
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/name: validatingwebhookconfiguration
     app.kubernetes.io/instance: validating-webhook-configuration
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: validating-webhook-configuration
   annotations:

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -7,8 +7,8 @@
 #     app.kubernetes.io/name: mutatingwebhookconfiguration
 #     app.kubernetes.io/instance: mutating-webhook-configuration
 #     app.kubernetes.io/component: webhook
-#     app.kubernetes.io/created-by: cnf-certsuite-operator
-#     app.kubernetes.io/part-of: cnf-certsuite-operator
+#     app.kubernetes.io/created-by: certsuite-operator
+#     app.kubernetes.io/part-of: certsuite-operator
 #     app.kubernetes.io/managed-by: kustomize
 #   name: mutating-webhook-configuration
 #   annotations:
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/name: validatingwebhookconfiguration
     app.kubernetes.io/instance: validating-webhook-configuration
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: validating-webhook-configuration
   annotations:

--- a/config/k8plugincert/certificate.yaml
+++ b/config/k8plugincert/certificate.yaml
@@ -6,16 +6,16 @@ metadata:
     app.kubernetes.io/name: certificate
     app.kubernetes.io/instance: console-plugin-cert
     app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: console-plugin-cert
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   dnsNames:
-  - cnf-certsuite-plugin.cnf-certsuite-operator.svc
-  - cnf-certsuite-plugin.cnf-certsuite-operator.svc.cluster.local
+  - certsuite-plugin.certsuite-operator.svc
+  - certsuite-plugin.certsuite-operator.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: cnf-certsuite-selfsigned-issuer
+    name: certsuite-selfsigned-issuer
   secretName: console-serving-cert

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:

--- a/config/manifests/bases/cnfpod-permissions/cnf_certsuite_rolebinding.yaml
+++ b/config/manifests/bases/cnfpod-permissions/cnf_certsuite_rolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: cnf-certsuite-rolebinding
+    app.kubernetes.io/instance: certsuite-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: cluster-rolebinding
 roleRef:

--- a/config/manifests/bases/redhat-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/redhat-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
@@ -4,8 +4,8 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    console.openshift.io/plugins: '["cnf-certsuite-plugin"]'
-  name: cnf-certsuite-operator.v0.0.0
+    console.openshift.io/plugins: '["certsuite-plugin"]'
+  name: redhat-best-practices-for-k8s-certsuite-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -17,9 +17,9 @@ spec:
       kind: CnfCertificationSuiteRun
       name: cnfcertificationsuiteruns.cnf-certifications.redhat.com
       version: v1alpha1
-  description: Deploys the CNF Certification Suite Pod to run the certification suite
-    on target CNF resources.
-  displayName: CNF Certification Suite Operator
+  description: Deploys Red Hat's Best Practices for Kubernetes Certification Suite
+    Pod to run the Certification Test Suite on target resources.
+  displayName: Red Hat's Best Practices for Kubernetes Certification Suite Operator
   icon:
   - base64data: ""
     mediatype: ""
@@ -42,7 +42,7 @@ spec:
   - cloud
   - telco
   links:
-  - name: CNF Certification Suite Operator
+  - name: Red Hat's Best Practices for Kubernetes Certification Suite Operator
     url: https://github.com/redhat-best-practices-for-k8s/certsuite-operator
   maturity: alpha
   provider:

--- a/config/manifests/bases/rh-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rh-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     console.openshift.io/plugins: '["certsuite-plugin"]'
-  name: redhat-best-practices-for-k8s-certsuite-operator.v0.0.0
+  name: rh-best-practices-for-k8s-certsuite-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,7 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/redhat-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
+- bases/rh-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,7 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/cnf-certsuite-operator.clusterserviceversion.yaml
+- bases/redhat-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: metrics-reader
 rules:

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: proxy-role
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: proxy-role
 rules:

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: proxy-rolebinding
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: proxy-rolebinding
 roleRef:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system

--- a/config/rbac/cnfcertificationsuiterun_editor_role.yaml
+++ b/config/rbac/cnfcertificationsuiterun_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: cnfcertificationsuiterun-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: cnfcertificationsuiterun-editor-role
 rules:

--- a/config/rbac/cnfcertificationsuiterun_viewer_role.yaml
+++ b/config/rbac/cnfcertificationsuiterun_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: cnfcertificationsuiterun-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: cnfcertificationsuiterun-viewer-role
 rules:

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: role
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,7 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: manager-role
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: manager-clusterrolebinding
 roleRef:
@@ -26,8 +26,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: serviceaccount
     app.kubernetes.io/instance: controller-manager-sa
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/config/samples/cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml
+++ b/config/samples/cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml
@@ -4,19 +4,19 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-sample
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
   logLevel: "info"
   timeout: "2h"
 
-  configMapName: "cnf-certsuite-config"
-  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
+  configMapName: "certsuite-config"
+  preflightSecretName : "certsuite-preflight-dockerconfig"
   enableDataCollection: false
   showAllResultsLogs: false
   showCompliantResourcesAlways: false

--- a/config/samples/extra/certsuite-configmap.yaml
+++ b/config/samples/extra/certsuite-configmap.yaml
@@ -2,23 +2,25 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cnf-certsuite-config
-  namespace: cnf-certsuite-operator
+  name: certsuite-config
+  namespace: certsuite-operator
 data:
   tnf_config.yaml: |
     targetNameSpaces:
       - name: tnf
     podsUnderTestLabels:
-      - "test-network-function.com/generic: target"
+      - "redhat-best-practices-for-k8s.com/generic: target"
     # deprecated operator label ("test-network-function.com/operator:"") still configured by default, no need to add it here
     operatorsUnderTestLabels:
-      - "test-network-function.com/operator1:new"
+      - "redhat-best-practices-for-k8s.com/operator:target"
+      - "redhat-best-practices-for-k8s.com/operator1:new"
+      - "cnf/test:cr-scale-operator"
     targetCrdFilters:
       - nameSuffix: "group1.test.com"
         scalable: false
-      - nameSuffix: "test-network-function.com"
+      - nameSuffix: "redhat-best-practices-for-k8s.com"
         scalable: false
-      - nameSuffix: "tutorial.my.domain"
+      - nameSuffix: "memcacheds.cache.example.com"
         scalable: true
     managedDeployments:
       - name: jack

--- a/config/samples/extra/certsuite-preflight-secret.yaml
+++ b/config/samples/extra/certsuite-preflight-secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cnf-certsuite-preflight-dockerconfig
-  namespace: cnf-certsuite-operator
+  name: certsuite-preflight-dockerconfig
+  namespace: certsuite-operator
 type: Opaque
 data:
   # Sample of empty content, base64-coded: '{ "auths": {} }'

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,13 +1,16 @@
 ## Append samples of your project ##
 resources:
 - cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml
+- extra/certsuite-configmap.yaml
+- extra/certsuite-preflight-secret.yaml
 
 ## Uncomment this two files (configmap+secret) to create a runnable test CR in the test namespace.
 ## Then run them with: oc kustomize config/samples | oc apply -f -
-#- extra/cnf-certsuite-configmap.yaml
-#- extra/cnf-certsuite-preflight-secret.yaml
+#- extra/certsuite-configmap.yaml
+#- extra/certsuite-preflight-secret.yaml
 
 #+kubebuilder:scaffold:manifestskustomizesamples
 
-namespace: cnf-certsuite-operator
-
+namespace: certsuite-operator
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/olm/catalogsource.yaml
+++ b/config/samples/olm/catalogsource.yaml
@@ -1,12 +1,12 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: cnf-certsuite-operator-olm-catalog
-  namespace: cnf-certsuite-operator
+  name: certsuite-operator-olm-catalog
+  namespace: certsuite-operator
 spec:
   sourceType: grpc
   image: quay.io/redhat-best-practices-for-k8s/certsuite-operator-catalog:v0.0.1
-  displayName: CNF Certification Suite OLM Test Catalog
+  displayName: OLM Test Catalog for the certsuite operator
   publisher: RedHat.com
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/samples/olm/kustomization.yaml
+++ b/config/samples/olm/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 - operatorgroup.yaml
 - subscription.yaml
 
-namespace: cnf-certsuite-operator
+namespace: certsuite-operator

--- a/config/samples/olm/namespace.yaml
+++ b/config/samples/olm/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cnf-certsuite-operator
+  name: certsuite-operator

--- a/config/samples/olm/operatorgroup.yaml
+++ b/config/samples/olm/operatorgroup.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
   name: my-group
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   targetNamespaces:
-    - "cnf-certsuite-operator"
+    - "certsuite-operator"

--- a/config/samples/olm/subscription.yaml
+++ b/config/samples/olm/subscription.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   sourceNamespace: certsuite-operator
   channel: alpha
-  name: redhat-best-practices-for-k8s-certsuite-operator
+  name: rh-best-practices-for-k8s-certsuite-operator
   source: certsuite-operator-olm-catalog

--- a/config/samples/olm/subscription.yaml
+++ b/config/samples/olm/subscription.yaml
@@ -1,10 +1,10 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: cnf-certsuite-operator
-  namespace: cnf-certsuite-operator
+  name: certsuite-operator
+  namespace: certsuite-operator
 spec:
-  sourceNamespace: cnf-certsuite-operator
+  sourceNamespace: certsuite-operator
   channel: alpha
-  name: cnf-certsuite-operator
-  source: cnf-certsuite-operator-olm-catalog
+  name: redhat-best-practices-for-k8s-certsuite-operator
+  source: certsuite-operator-olm-catalog

--- a/config/samples/validation-test/configmaps/configmap4.yaml
+++ b/config/samples/validation-test/configmaps/configmap4.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cnf-certsuite-invalid-config4
-  namespace: cnf-certsuite-operator
+  name: certsuite-invalid-config4
+  namespace: certsuite-operator
 data:
   

--- a/config/samples/validation-test/configmaps/configmap5.yaml
+++ b/config/samples/validation-test/configmaps/configmap5.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cnf-certsuite-invalid-config5
-  namespace: cnf-certsuite-operator
+  name: certsuite-invalid-config5
+  namespace: certsuite-operator
 data:
   tnf_config.yaml: 

--- a/config/samples/validation-test/invalid_run1.yaml
+++ b/config/samples/validation-test/invalid_run1.yaml
@@ -7,11 +7,11 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-invalid-sample1
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
@@ -19,4 +19,4 @@ spec:
   timeout: "2h"
 
   configMapName: ""
-  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
+  preflightSecretName : "certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run10.yaml
+++ b/config/samples/validation-test/invalid_run10.yaml
@@ -6,16 +6,16 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-sample10
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
   logLevel: "unsupported-log-level"
   timeout: "2h"
 
-  configMapName: "cnf-certsuite-config"
-  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
+  configMapName: "certsuite-config"
+  preflightSecretName : "certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run2.yaml
+++ b/config/samples/validation-test/invalid_run2.yaml
@@ -7,18 +7,18 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-invalid-sample2
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
   logLevel: "info"
   timeout: "2h"
 
-  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
+  preflightSecretName : "certsuite-preflight-dockerconfig"
 
 ---
 

--- a/config/samples/validation-test/invalid_run3.yaml
+++ b/config/samples/validation-test/invalid_run3.yaml
@@ -7,11 +7,11 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-sample3
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
@@ -19,4 +19,4 @@ spec:
   timeout: "2h"
 
   configMapName: "non-exist-configmap"
-  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
+  preflightSecretName : "certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run4.yaml
+++ b/config/samples/validation-test/invalid_run4.yaml
@@ -7,16 +7,16 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-invalid-sample4
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
   logLevel: "info"
   timeout: "2h"
 
-  configMapName: "cnf-certsuite-invalid-config4"
-  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
+  configMapName: "certsuite-invalid-config4"
+  preflightSecretName : "certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run5.yaml
+++ b/config/samples/validation-test/invalid_run5.yaml
@@ -7,16 +7,16 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-invalid-sample5
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
   logLevel: "info"
   timeout: "2h"
 
-  configMapName: "cnf-certsuite-invalid-config5"
-  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
+  configMapName: "certsuite-invalid-config5"
+  preflightSecretName : "certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run6.yaml
+++ b/config/samples/validation-test/invalid_run6.yaml
@@ -7,16 +7,16 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-sample6
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
   logLevel: "info"
   timeout: "2h"
 
-  configMapName: "cnf-certsuite-config"
+  configMapName: "certsuite-config"
   preflightSecretName : ""

--- a/config/samples/validation-test/invalid_run7.yaml
+++ b/config/samples/validation-test/invalid_run7.yaml
@@ -7,16 +7,16 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-sample7
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
   logLevel: "info"
   timeout: "2h"
 
-  configMapName: "cnf-certsuite-config"
+  configMapName: "certsuite-config"
   preflightSecretName : "non-exist-secret"

--- a/config/samples/validation-test/invalid_run8.yaml
+++ b/config/samples/validation-test/invalid_run8.yaml
@@ -7,16 +7,16 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-sample8
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
   logLevel: "info"
   timeout: "2h"
 
-  configMapName: "cnf-certsuite-config"
-  preflightSecretName : "cnf-certsuite-invalid-preflight-dockerconfig8"
+  configMapName: "certsuite-config"
+  preflightSecretName : "certsuite-invalid-preflight-dockerconfig8"

--- a/config/samples/validation-test/invalid_run9.yaml
+++ b/config/samples/validation-test/invalid_run9.yaml
@@ -6,16 +6,16 @@ metadata:
   labels:
     app.kubernetes.io/name: cnfcertificationsuiterun
     app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
   name: cnfcertificationsuiterun-sample9
-  namespace: cnf-certsuite-operator
+  namespace: certsuite-operator
 spec:
   # TODO(user): Add fields here
   labelsFilter: "observability"
   logLevel: "info"
   timeout: "2h"
 
-  configMapName: "cnf-certsuite-config"
-  preflightSecretName : "cnf-certsuite-invalid-preflight-dockerconfig9"
+  configMapName: "certsuite-config"
+  preflightSecretName : "certsuite-invalid-preflight-dockerconfig9"

--- a/config/samples/validation-test/preflight_secrets/preflight_secret8.yaml
+++ b/config/samples/validation-test/preflight_secrets/preflight_secret8.yaml
@@ -4,8 +4,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cnf-certsuite-invalid-preflight-dockerconfig8
-  namespace: cnf-certsuite-operator
+  name: certsuite-invalid-preflight-dockerconfig8
+  namespace: certsuite-operator
 type: Opaque
 data:
   # Sample of empty content, base64-coded: '{ "auths": {} }'

--- a/config/samples/validation-test/preflight_secrets/preflight_secret9.yaml
+++ b/config/samples/validation-test/preflight_secrets/preflight_secret9.yaml
@@ -4,8 +4,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cnf-certsuite-invalid-preflight-dockerconfig9
-  namespace: cnf-certsuite-operator
+  name: certsuite-invalid-preflight-dockerconfig9
+  namespace: certsuite-operator
 type: Opaque
 data:
   # Sample of empty content, base64-coded: '{ "auths": {} }'

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: cnf-certsuite-operator
-    app.kubernetes.io/part-of: cnf-certsuite-operator
+    app.kubernetes.io/created-by: certsuite-operator
+    app.kubernetes.io/part-of: certsuite-operator
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system

--- a/internal/controller/cnf-cert-job/cnfcertjob.go
+++ b/internal/controller/cnf-cert-job/cnfcertjob.go
@@ -13,8 +13,10 @@ import (
 const (
 	// Be careful when changing this SA name.
 	// 1. It must match the flag --extra-service-accounts in "make bundle".
-	// 2. The prefix is "cnf-certsuite-". It should match the field namePrefix field in config/default/kustomization.yaml.
-	clusterAccessServiceAccountName = "cnf-certsuite-cluster-access"
+	// 2. The prefix is "certsuite-". It should match the field namePrefix field in config/default/kustomization.yaml.
+	clusterAccessServiceAccountName = "certsuite-cluster-access"
+
+	certsuiteContainerImage = "quay.io/redhat-best-practices-for-k8s/certsuite:unstable"
 )
 
 func New(options ...func(*corev1.Pod) error) (*corev1.Pod, error) {
@@ -73,7 +75,7 @@ func newInitialJobPod() *corev1.Pod {
 				},
 				{
 					Name:    definitions.CnfCertSuiteContainerName,
-					Image:   "quay.io/testnetworkfunction/cnf-certification-test:unstable",
+					Image:   certsuiteContainerImage,
 					Command: []string{"certsuite"},
 					Args: []string{"run", "--output-dir", definitions.CnfCertSuiteResultsFolder,
 						"--config-file", definitions.CnfCertSuiteConfigFilePath,

--- a/internal/controller/cnfcertificationsuiterun_controller.go
+++ b/internal/controller/cnfcertificationsuiterun_controller.go
@@ -64,16 +64,16 @@ const (
 	defaultCnfCertSuiteTimeout = time.Hour
 )
 
-// +kubebuilder:rbac:groups=cnf-certifications.redhat.com,namespace=cnf-certsuite-operator,resources=cnfcertificationsuiteruns,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=cnf-certifications.redhat.com,namespace=cnf-certsuite-operator,resources=cnfcertificationsuiteruns/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=cnf-certifications.redhat.com,namespace=cnf-certsuite-operator,resources=cnfcertificationsuiteruns/finalizers,verbs=update
+// +kubebuilder:rbac:groups=cnf-certifications.redhat.com,namespace=certsuite-operator,resources=cnfcertificationsuiteruns,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cnf-certifications.redhat.com,namespace=certsuite-operator,resources=cnfcertificationsuiteruns/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cnf-certifications.redhat.com,namespace=certsuite-operator,resources=cnfcertificationsuiteruns/finalizers,verbs=update
 
-// +kubebuilder:rbac:groups="",namespace=cnf-certsuite-operator,resources=pods,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",namespace=cnf-certsuite-operator,resources=secrets;configMaps,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",namespace=cnf-certsuite-operator,resources=namespaces;services;configMaps,verbs=create
+// +kubebuilder:rbac:groups="",namespace=certsuite-operator,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",namespace=certsuite-operator,resources=secrets;configMaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",namespace=certsuite-operator,resources=namespaces;services;configMaps,verbs=create
 
 // +kubebuilder:rbac:groups="console.openshift.io",resources=consoleplugins,verbs=create
-// +kubebuilder:rbac:groups="apps",namespace=cnf-certsuite-operator,resources=deployments,verbs=create
+// +kubebuilder:rbac:groups="apps",namespace=certsuite-operator,resources=deployments,verbs=create
 
 func ignoreUpdatePredicate() predicate.Predicate {
 	return predicate.Funcs{

--- a/internal/controller/cnfcertificationsuiterun_controller_test.go
+++ b/internal/controller/cnfcertificationsuiterun_controller_test.go
@@ -101,12 +101,12 @@ func Test_getCertSuiteContainerExitStatus(t *testing.T) {
 			certSuitePod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "cnf-job-sample",
-					Namespace: "cnf-certsuite-operator",
+					Namespace: "certsuite-operator",
 				},
 				Status: corev1.PodStatus{},
 			},
 			wantExitStatus: 0,
-			wantError:      fmt.Errorf("failed to get cert suite exit status: container not found in pod cnf-job-sample (ns cnf-certsuite-operator)"),
+			wantError:      fmt.Errorf("failed to get cert suite exit status: container not found in pod cnf-job-sample (ns certsuite-operator)"),
 		},
 	}
 	for _, tc := range tests {
@@ -138,13 +138,13 @@ func TestCnfCertificationSuiteRunReconciler_waitForCertSuitePodToComplete(t *tes
 			timeOut:            10 * time.Second,
 			phase:              corev1.PodRunning,
 			wantExitStatusCode: 0,
-			wantError:          fmt.Errorf("timeout (10s) reached while waiting for cert suite pod cnf-certsuite-operator/cnf-job-sample to finish"),
+			wantError:          fmt.Errorf("timeout (10s) reached while waiting for cert suite pod certsuite-operator/cnf-job-sample to finish"),
 		},
 	}
 
 	certSuitePodNamespacedName := types.NamespacedName{
 		Name:      "cnf-job-sample",
-		Namespace: "cnf-certsuite-operator",
+		Namespace: "certsuite-operator",
 	}
 	for _, tc := range tests {
 		certSuitePod := &corev1.Pod{
@@ -189,7 +189,7 @@ func TestCnfCertificationSuiteRunReconciler_updateStatus(t *testing.T) {
 			},
 			runCRNamespacedName: types.NamespacedName{
 				Name:      "cnf-run-sample",
-				Namespace: "cnf-certsuite-operator",
+				Namespace: "certsuite-operator",
 			},
 			wantErr: false,
 		},
@@ -213,7 +213,7 @@ func TestCnfCertificationSuiteRunReconciler_updateStatus(t *testing.T) {
 	runCR := &cnfcertificationsv1alpha1.CnfCertificationSuiteRun{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "cnf-run-sample",
-			Namespace: "cnf-certsuite-operator",
+			Namespace: "certsuite-operator",
 		},
 		Status: cnfcertificationsv1alpha1.CnfCertificationSuiteRunStatus{
 			Phase: definitions.CnfCertificationSuiteRunStatusCertSuiteRunning,

--- a/plugin/console-plugin.yaml
+++ b/plugin/console-plugin.yaml
@@ -13,7 +13,7 @@ spec:
     service:
       basePath: /
       name: cnf-certsuite-plugin
-      namespace: cnf-certsuite-operator
+      namespace: certsuite-operator
       port: 9001
     type: Service
   displayName: OpenShift Console Demo Plugin

--- a/plugin/deployment.yaml
+++ b/plugin/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: nginx-conf
           configMap:
             name: nginx-configmap
-            namespace: cnf-certsuite-operator
+            namespace: certsuite-operator
             defaultMode: 420
       restartPolicy: Always
       dnsPolicy: ClusterFirst

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -6,14 +6,14 @@
 # uploading the images to an external registry (quay/docker).
 #
 # The operator is deployed in the namespace set by env var CNF_CERTSUITE_OPERATOR_NAMESPACE
-# or in the defaulted namespace "cnf-certsuite-operator" if that env var is not found.
+# or in the defaulted namespace "certsuite-operator" if that env var is not found.
 #
 
 # Bash settings: display (expanded) commands and fast exit on first error.
 set -o xtrace
 set -o errexit
 
-DEFAULT_CNF_CERTSUITE_OPERATOR_NAMESPACE="cnf-certsuite-operator"
+DEFAULT_CNF_CERTSUITE_OPERATOR_NAMESPACE="certsuite-operator"
 DEFAULT_TEST_VERSION="0.0.1-test"
 DEFAULT_SIDECAR_IMG="ci-cnf-op-sidecar:v$DEFAULT_TEST_VERSION"
 DEFAULT_IMG="ci-cnf-op:v$DEFAULT_TEST_VERSION"
@@ -38,4 +38,4 @@ popd
 make deploy
 
 # step: Wait for the controller's containers to be ready
-oc wait --for=condition=ready pod --all=true -n cnf-certsuite-operator --timeout=2m
+oc wait --for=condition=ready pod --all=true -n certsuite-operator --timeout=2m

--- a/scripts/ci/smoke_test.sh
+++ b/scripts/ci/smoke_test.sh
@@ -16,7 +16,7 @@
 set -o xtrace
 set -o errexit
 
-DEFAULT_CNF_CERTSUITE_OPERATOR_NAMESPACE="cnf-certsuite-operator"
+DEFAULT_CNF_CERTSUITE_OPERATOR_NAMESPACE="certsuite-operator"
 CNF_CERTSUITE_OPERATOR_NAMESPACE=${CNF_CERTSUITE_OPERATOR_NAMESPACE:-$DEFAULT_CNF_CERTSUITE_OPERATOR_NAMESPACE}
 
 # Checks every $2 secs that .status.phase is $1.
@@ -31,7 +31,7 @@ checkStatusPhase() {
     endtime=$(date -ud "$runtime" +%s)
 
     while [[ $(date -u +%s) -le $endtime ]]; do
-        actual_phase=$(oc get cnfcertificationsuiteruns -n cnf-certsuite-operator cnfcertificationsuiterun-sample -o json | jq -r '.status.phase')
+        actual_phase=$(oc get cnfcertificationsuiteruns -n certsuite-operator cnfcertificationsuiterun-sample -o json | jq -r '.status.phase')
         if [ "$actual_phase" == "$expected_phase" ]; then
             echo "Phase ${expected_phase} found!"
             return 0

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -27,6 +27,6 @@ import (
 // Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	fmt.Fprintf(GinkgoWriter, "Starting cnf-certsuite-operator suite\n")
+	fmt.Fprintf(GinkgoWriter, "Starting certsuite-operator suite\n")
 	RunSpecs(t, "e2e suite")
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite-operator/test/utils"
 )
 
-const namespace = "cnf-certsuite-operator-system"
+const namespace = "certsuite-operator-system"
 
 var _ = Describe("controller", Ordered, func() {
 	BeforeAll(func() {
@@ -60,7 +60,7 @@ var _ = Describe("controller", Ordered, func() {
 			var err error
 
 			// projectimage stores the name of the image used in the example
-			var projectimage = "example.com/cnf-certsuite-operator:v0.0.1"
+			var projectimage = "example.com/certsuite-operator:v0.0.1"
 			projectimageStr := fmt.Sprintf("IMG=%s", projectimage)
 
 			By("building the manager(Operator) image")


### PR DESCRIPTION
New package name: `redhat-best-practices-for-k8s-certsuite-operator`.

```
$ oc get packagemanifests -n certsuite-operator | grep cert
redhat-best-practices-for-k8s-certsuite-operator   OLM Test Catalog for the certsuite operator   3m55s
```
The certsuite's ServiceAccount, the certsuite container image and some of the sample config yaml have also been updated.

There's still some work to do:
1. Remove "cnf-" from plugin resources' names.
2. Rename the CRD to remove the Cnf/cnf prefixes. The domain and api group must also be updated.

I will address (2) in the next PR.