### PR TITLE
Update operator-sdk to v1.36.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Download operator-sdk
         env:
           OPERATOR_SDK_BIN: operator-sdk_linux_amd64
-          OPERATOR_SDK_DL_URL: https://github.com/operator-framework/operator-sdk/releases/download/v1.34.2
+          OPERATOR_SDK_DL_URL: https://github.com/operator-framework/operator-sdk/releases/download/v1.36.1
           OPERATOR_SDK_DEST_FOLDER: /usr/local/bin
         run: |
           curl --location --remote-name ${OPERATOR_SDK_DL_URL}/${OPERATOR_SDK_BIN}

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.34.2
+OPERATOR_SDK_VERSION ?= v1.36.1
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/redhat-best-practices-for-k8s/certsuite-operator:v$(VERSION)

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=rh-best-practices-for-k8s-certsuite-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.36.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/rh-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rh-best-practices-for-k8s-certsuite-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/plugins: '["certsuite-plugin"]'
     createdAt: "2024-08-09T12:07:19Z"
-    operators.operatorframework.io/builder: operator-sdk-v1.34.2
+    operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: rh-best-practices-for-k8s-certsuite-operator.v0.0.1
   namespace: placeholder

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: rh-best-practices-for-k8s-certsuite-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.36.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -8,7 +8,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.34.2
+    image: quay.io/operator-framework/scorecard-test:v1.36.1
     labels:
       suite: olm
       test: olm-status-descriptors-test


### PR DESCRIPTION
https://github.com/operator-framework/operator-sdk/releases/tag/v1.36.1

Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2330 