### PR TITLE
Rename operator's console plugin resources and update plugin's image

### DIFF
--- a/plugin/configmap.yaml
+++ b/plugin/configmap.yaml
@@ -4,10 +4,10 @@ metadata:
   name: nginx-configmap
   namespace: OPERATOR_NS_PLACEHOLDER
   labels:
-    app: cnf-certsuite-plugin
-    app.kubernetes.io/component: cnf-certsuite-plugin
-    app.kubernetes.io/instance: cnf-certsuite-plugin
-    app.kubernetes.io/part-of: cnf-certsuite-plugin
+    app: certsuite-operator-plugin
+    app.kubernetes.io/component: certsuite-operator-plugin
+    app.kubernetes.io/instance: certsuite-operator-plugin
+    app.kubernetes.io/part-of: certsuite-operator-plugin
 data:
   nginx.conf: |
     error_log /dev/stdout info;

--- a/plugin/console-plugin.yaml
+++ b/plugin/console-plugin.yaml
@@ -1,18 +1,18 @@
 apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
-  name: cnf-certsuite-plugin
+  name: certsuite-operator-plugin
   namespace: OPERATOR_NS_PLACEHOLDER
   labels:
-    app: cnf-certsuite-plugin
-    app.kubernetes.io/component: cnf-certsuite-plugin
-    app.kubernetes.io/instance: cnf-certsuite-plugin
-    app.kubernetes.io/part-of: cnf-certsuite-plugin
+    app: certsuite-operator-plugin
+    app.kubernetes.io/component: certsuite-operator-plugin
+    app.kubernetes.io/instance: certsuite-operator-plugin
+    app.kubernetes.io/part-of: certsuite-operator-plugin
 spec:
   backend:
     service:
       basePath: /
-      name: cnf-certsuite-plugin
+      name: certsuite-operator-plugin
       namespace: certsuite-operator
       port: 9001
     type: Service

--- a/plugin/deployment.yaml
+++ b/plugin/deployment.yaml
@@ -1,27 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cnf-certsuite-plugin
+  name: certsuite-operator-plugin
   namespace: OPERATOR_NS_PLACEHOLDER
   labels:
-    app: cnf-certsuite-plugin
-    app.kubernetes.io/component: cnf-certsuite-plugin
-    app.kubernetes.io/instance: cnf-certsuite-plugin
-    app.kubernetes.io/part-of: cnf-certsuite-plugin
-    app.openshift.io/runtime-namespace: cnf-certsuite-plugin
+    app: certsuite-operator-plugin
+    app.kubernetes.io/component: certsuite-operator-plugin
+    app.kubernetes.io/instance: certsuite-operator-plugin
+    app.kubernetes.io/part-of: certsuite-operator-plugin
+    app.openshift.io/runtime-namespace: certsuite-operator-plugin
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: cnf-certsuite-plugin
+      app: certsuite-operator-plugin
   template:
     metadata:
       labels:
-        app: cnf-certsuite-plugin
+        app: certsuite-operator-plugin
     spec:
       containers:
-        - name: cnf-certsuite-plugin
-          image: quay.io/rh_ee_shmoran/cnf-plugin:test3
+        - name: certsuite-operator-plugin
+          image: quay.io/redhat-best-practices-for-k8s/certsuite-operator-plugin:v0.0.1
           ports:
             - containerPort: 9001
               protocol: TCP

--- a/plugin/service.yaml
+++ b/plugin/service.yaml
@@ -3,13 +3,13 @@ kind: Service
 metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: console-serving-cert
-  name: cnf-certsuite-plugin
+  name: certsuite-operator-plugin
   namespace: OPERATOR_NS_PLACEHOLDER
   labels:
-    app: cnf-certsuite-plugin
-    app.kubernetes.io/component: cnf-certsuite-plugin
-    app.kubernetes.io/instance: cnf-certsuite-plugin
-    app.kubernetes.io/part-of: cnf-certsuite-plugin
+    app: certsuite-operator-plugin
+    app.kubernetes.io/component: certsuite-operator-plugin
+    app.kubernetes.io/instance: certsuite-operator-plugin
+    app.kubernetes.io/part-of: certsuite-operator-plugin
 spec:
   ports:
     - name: 9001-tcp
@@ -17,6 +17,6 @@ spec:
       port: 9001
       targetPort: 9001
   selector:
-    app: cnf-certsuite-plugin
+    app: certsuite-operator-plugin
   type: ClusterIP
   sessionAffinity: None


### PR DESCRIPTION
This PR renames the resources names and labels from `cnf-certsuite-plugin` to `certsuite-operator-plugin` corresponding to console plugin name update in plugin's repo (see [PR](https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin/pull/7)).

The plugin's image has also been updated to `quay.io/redhat-best-practices-for-k8s/certsuite-operator-plugin:v0.0.1` which is based on same PR.
Next: plugin's image will be created by a workflow and will be set accordingly (or dynamically).