### PR TITLE
Update GolangCI-lint to v1.60.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.60.1
+GOLANGCI_LINT_VERSION ?= v1.60.3
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2372