### PR TITLE
Do not remove plugin resources on operator uninstall.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -161,8 +161,8 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "CertsuiteRun")
 		os.Exit(1)
 	}
-	consolePluginRemovalDone := make(chan error)
-	if err := r.HandleConsolePlugin(consolePluginRemovalDone); err != nil {
+
+	if err := r.HandleConsolePlugin(); err != nil {
 		setupLog.Error(err, "error has occurred while handling console plugin")
 		os.Exit(1)
 	}
@@ -186,12 +186,6 @@ func main() {
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
-	}
-
-	// Wait for openshift's console plugin removal procedure to finish.
-	if err := <-consolePluginRemovalDone; err != nil {
-		setupLog.Error(err, "failed to remove openshift console plugin resources")
 		os.Exit(1)
 	}
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,20 +22,19 @@ rules:
   - ""
   resources:
   - configMaps
-  - namespaces
-  - services
   verbs:
   - create
   - delete
-- apiGroups:
-  - ""
-  resources:
-  - configMaps
-  - secrets
-  verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:
@@ -48,6 +47,21 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
When removing the CSV, OLM can remove controller's role or rolebinding before raising the SIGTERM on the controller, which makes the controller to fail to delete the plugin resources due to lack of permissions.

This is a workaround for some issues related to plugin's resources when uninstalling the operator. A better approach for plugin install/uninstall is yet to implement.

To fully disable/uninstall the operator plugin, it must be removed manually after the operator has been uninstalled.

If they're not removed and the operator is installed again, the resources are applied but the error is ignored to let the controller continue working normally.

Also:
- Minor changes to controller RBAC, to have just one resource per verb list. Otherwise, the same resource can appear in several verbs list making it a bit hard to follow.
- Added logging traces to the console plugin resources creation/removal.