### PR TITLE
Update GolangCI-lint to v1.63.3

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.62
+          version: v1.63
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,6 +111,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.62.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.63.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.62.2
+GOLANGCI_LINT_VERSION ?= v1.63.3
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2667