### PR TITLE
Makefile: improvements and new make release target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ git clone https://github.com/redhat-best-practices-for-k8s/certsuite-operator.gi
 1. Export OLM catalog image and namespace:
 
     ```sh
-    export OLM_INSTALL_IMG_CATALOG=<your-registry.com>/<your-repo>/certsuite-operator-catalog:<version>
+    export OLM_CATALOG=<your-registry.com>/<your-repo>/certsuite-operator-catalog:<version>
     export OLM_INSTALL_NAMESPACE=<your-namespace>
     ```
 
@@ -69,8 +69,8 @@ git clone https://github.com/redhat-best-practices-for-k8s/certsuite-operator.gi
     they will be set by default to:
 
     ```sh
-    OLM_INSTALL_IMG_CATALOG = quay.io/redhat-best-practices-for-k8s/certsuite-operator-catalog:latest
-    OLM_INSTALL_NAMESPACE = certsuite-operator
+    OLM_CATALOG=quay.io/redhat-best-practices-for-k8s/certsuite-operator-catalog:latest
+    OLM_INSTALL_NAMESPACE=certsuite-operator
     ```
 
 2. Install Cnf Certification Operator:\

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,9 +6,5 @@ images:
 - name: controller
   newName: quay.io/redhat-best-practices-for-k8s/certsuite-operator
   newTag: v0.0.1
-patches:
-- patch: '[{"op": "replace", "path": "/spec/template/spec/containers/0/env/1", "value":
-    {"name": "SIDECAR_APP_IMG", "value": "quay.io/redhat-best-practices-for-k8s/certsuite-operator-sidecar:v0.0.1"}
-    }]'
-  target:
-    kind: Deployment
+commonAnnotations:
+  certsuite-operator/sidecar-image: quay.io/redhat-best-practices-for-k8s/certsuite-operator-sidecar:v0.0.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,10 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: SIDECAR_APP_IMG
-          value: quay.io/redhat-best-practices-for-k8s/certsuite-operator-sidecar:v0.0.1
+          valueFrom:
+            fieldRef:
+              fieldPath:
+                metadata.annotations['certsuite-operator/sidecar-image']
         - name: CONTROLLER_NS
           valueFrom:
             fieldRef:


### PR DESCRIPTION
A new target "release" has been created. It builds the sidecar, controller, bundle and catalog container images and push them to the registry. If not explicitly set using env vars, all the images will use the base tag "quay.io/redhat-best-practices-for-k8s/certsuite-operator". Valid docker/podman local credentials are needed for this. The container images and the command to install the new release will be shown at the end, like this:
```
$ VERSION=0.0.2 make release
...
make[1]: Leaving directory '/home/greyerof/github/certsuite-operator'
Release 0.0.2 successfully built and pushed to registry. Images:
  Controller : quay.io/redhat-best-practices-for-k8s/certsuite-operator:v0.0.2
  Sidecar    : quay.io/redhat-best-practices-for-k8s/certsuite-operator-sidecar:v0.0.2
  Bundle     : quay.io/redhat-best-practices-for-k8s/certsuite-operator-bundle:v0.0.2
  Catalog    : quay.io/redhat-best-practices-for-k8s/certsuite-operator-catalog:v0.0.2
Type this command to install it with OLM in namespace certsuite-operator
  OLM_CATALOG=quay.io/redhat-best-practices-for-k8s/certsuite-operator-catalog:v0.0.2 make olm-install
```
If no VERSION env var is provided, it will use the defaulted value inside the Makefile (currently 0.0.1) so proceed with caution as it will overwrite that version if it already exists in the registry.

To create custom dev/debug images to be pushed to a private registry/repo, the IMAGE_TAG_BASE env var can be used:
```
$ VERSION=0.0.9 IMAGE_TAG_BASE=quay.io/greyerof/cnf-op make release
...
Release 0.0.9 built and pushed to registry. Images:
  Controller : quay.io/greyerof/cnf-op:v0.0.9
  Sidecar    : quay.io/greyerof/cnf-op-sidecar:v0.0.9
  Bundle     : quay.io/greyerof/cnf-op-bundle:v0.0.9
  Catalog    : quay.io/greyerof/cnf-op-catalog:v0.0.9
Type this command to install it with OLM in namespace certsuite-operator
  OLM_CATALOG=quay.io/greyerof/cnf-op-catalog:v0.0.9 make olm-install
```
Also, some more changes to avoid the need for so many local changes in the kustomization files when creating dev/test releases:
- Removed the kustomize command to apply the patch to replace the sidecar container image and switched to annotation usage instead.
- When installing with make olm-install, do not switch namespace or catalog's image if they're the default ones.