### PR TITLE
Fix golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,10 +28,7 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
   lll:
     line-length: 250
-  maligned:
-    suggest-new: true
   nolintlint:
-    allow-leading-space: false # disallow leading spaces. A space means the //nolint comment shows in `godoc` output.
     allow-unused: false # report any unused nolint directives
     require-explanation: false # do not require an explanation for nolint directives
     require-specific: true # require nolint directives to be specific about which linter is being skipped
@@ -106,10 +103,3 @@ issues:
       text: "unnecessaryDefer:"
     # Ignore static strings in tests
 
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.64.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ golangci-lint:
 	}
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
-	$(GOLANGCI_LINT) run --timeout 10m0s
+lint: golangci-lint ## Run all linters
+	$(GOLANGCI_LINT) config verify && $(GOLANGCI_LINT) run --timeout 10m0s
 	checkmake --config=.checkmake Makefile
 	hadolint Dockerfile
 	# shfmt -d *.sh script


### PR DESCRIPTION
Invalid golangci-lint config is causing currently open PRs to fail the checks.
Also, added local config verify to match github action errors when invalid config is detected.