### PR TITLE
Update golangci-lint schema to v2

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -45,9 +45,8 @@ jobs:
         uses: mfinelli/setup-shfmt@v3
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,58 +1,18 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 60
-    statements: 45
-  goconst:
-    min-len: 4
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - whyNoLint
-  gocyclo:
-    min-complexity: 20
-  govet:
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  lll:
-    line-length: 250
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # do not require an explanation for nolint directives
-    require-specific: true # require nolint directives to be specific about which linter is being skipped
-  exhaustive:
-    default-signifies-exhaustive: true
+version: "2"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - errcheck
     - exhaustive
-    - copyloopvar
     - funlen
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -61,45 +21,75 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-  # do not enable:
-  # - asciicheck
-  # - depguard
-  # - dupl
-  # - gochecknoglobals
-  # - gochecknoinits
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - maligned
-  # - nakedret
-  # - nestif
-  # - noctx
-  # - prealloc
-  # - structcheck
-  # - testpackage
-  # - wsl
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Ignore magic numbers, inline strings and function length in tests.
-    - path: _test\.go
-      linters:
-        - goconst
-        - funlen
-    # Ignore line length for string assignments (do not try and wrap regex definitions)
-    - linters:
-        - lll
-      source: "^(.*= (\".*\"|`.*`))$"
-    # https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
-    # Ignore static strings in tests
-
+  settings:
+    dupl:
+      threshold: 100
+    exhaustive:
+      default-signifies-exhaustive: true
+    funlen:
+      lines: 60
+      statements: 45
+    goconst:
+      min-len: 4
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 20
+    govet:
+      settings:
+        printf:
+          funcs:
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    lll:
+      line-length: 250
+    nolintlint:
+      require-explanation: false
+      require-specific: true
+      allow-unused: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - funlen
+          - goconst
+        path: _test\.go
+      - linters:
+          - lll
+        source: ^(.*= (".*"|`.*`))$
+      - linters:
+          - gocritic
+        text: 'unnecessaryDefer:'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -123,17 +123,11 @@ test: manifests generate fmt vet envtest ## Run tests.
 test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
-GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.64.5
-golangci-lint:
-	@[ -f $(GOLANGCI_LINT) ] || { \
-	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(GOLANGCI_LINT_VERSION) ;\
-	}
+
 
 .PHONY: lint
-lint: golangci-lint ## Run all linters
-	$(GOLANGCI_LINT) config verify && $(GOLANGCI_LINT) run --timeout 10m0s
+lint: ## Run all linters
+	golangci-lint run --timeout 10m0s
 	checkmake --config=.checkmake Makefile
 	hadolint Dockerfile
 	# shfmt -d *.sh script

--- a/internal/controller/cnf-cert-job/cnfcertjob.go
+++ b/internal/controller/cnf-cert-job/cnfcertjob.go
@@ -111,14 +111,14 @@ func newInitialJobPod() *corev1.Pod {
 
 func WithPodName(podName string) func(*corev1.Pod) error {
 	return func(p *corev1.Pod) error {
-		p.ObjectMeta.Name = podName
+		p.Name = podName
 		return nil
 	}
 }
 
 func WithNamespace(namespace string) func(*corev1.Pod) error {
 	return func(p *corev1.Pod) error {
-		p.ObjectMeta.Namespace = namespace
+		p.Namespace = namespace
 		return nil
 	}
 }
@@ -242,7 +242,7 @@ func WithOwnerReference(ownerUID types.UID, ownerName, ownerKind, ownerAPIVersio
 			Name:       ownerName,
 			UID:        ownerUID,
 		}
-		p.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*ownerReference}
+		p.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		return nil
 	}
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,stylecheck
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,stylecheck,staticcheck
 )
 
 const (


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2875