### PR TITLE
Several fixes to adapt it to golang 1.25 and the new certsuite flag --intrusive

### DIFF
--- a/.github/workflows/certsuiterun_validation_test.yaml
+++ b/.github/workflows/certsuiterun_validation_test.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Removed unused docker images and go cache cleanup
         run: |
           df -h

--- a/.github/workflows/certsuiterun_validation_test.yaml
+++ b/.github/workflows/certsuiterun_validation_test.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install consoleplugin CRD to cluster
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/openshift/api/master/console/v1/zz_generated.crd-manifests/90_consoleplugins-Default.crd.yaml
+          kubectl apply -f https://raw.githubusercontent.com/openshift/api/refs/heads/master/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
 
       - name: More cleanup
         run: |

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -114,6 +114,11 @@ jobs:
           removeDefaultStorageClass: true
           removeControlPlaneTaint: true
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Build operator
         run: ./scripts/ci/build.sh
 
@@ -121,7 +126,7 @@ jobs:
         run: |
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
           kubectl wait --for=condition=ready pod --all=true -n cert-manager --timeout=5m
-      
+
       - name: Install consoleplugin CRD to cluster
         run: |
           kubectl apply -f https://raw.githubusercontent.com/openshift/api/master/console/v1/zz_generated.crd-manifests/90_consoleplugins-Default.crd.yaml

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Install consoleplugin CRD to cluster
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/openshift/api/master/console/v1/zz_generated.crd-manifests/90_consoleplugins-Default.crd.yaml
+          kubectl apply -f https://raw.githubusercontent.com/openshift/api/refs/heads/master/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
 
       - name: More cleanup
         run: |

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.15.0
+CONTROLLER_TOOLS_VERSION ?= v0.19.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.

--- a/internal/controller/cnf-cert-job/cnfcertjob.go
+++ b/internal/controller/cnf-cert-job/cnfcertjob.go
@@ -80,7 +80,7 @@ func newInitialJobPod() *corev1.Pod {
 					Args: []string{"run", "--output-dir", definitions.CnfCertSuiteResultsFolder,
 						"--config-file", definitions.CnfCertSuiteConfigFilePath,
 						"--preflight-dockerconfig", definitions.PreflightDockerConfigFilePath,
-						"--non-intrusive", "true",
+						"--intrusive", "false",
 					},
 					ImagePullPolicy: "Always",
 					VolumeMounts: []corev1.VolumeMount{

--- a/scripts/ci/smoke_test.sh
+++ b/scripts/ci/smoke_test.sh
@@ -32,11 +32,11 @@ checkStatusPhase() {
 
     while [[ $(date -u +%s) -le $endtime ]]; do
         # Show the pods and the certsuiterun CR in the operator namespace
-        oc get pods -n ${CNF_CERTSUITE_OPERATOR_NAMESPACE} -o wide
+        oc get pods -n "${CNF_CERTSUITE_OPERATOR_NAMESPACE}" -o wide
         oc get certsuiterun -n "${CNF_CERTSUITE_OPERATOR_NAMESPACE}"
 
         # Get and check the phase of the certsuiterun CR
-        actual_phase=$(oc get certsuiteruns -n ${CNF_CERTSUITE_OPERATOR_NAMESPACE} certsuiterun-sample -o json | jq -r '.status.phase')
+        actual_phase=$(oc get certsuiteruns -n "${CNF_CERTSUITE_OPERATOR_NAMESPACE}" certsuiterun-sample -o json | jq -r '.status.phase')
         if [ "$actual_phase" == "$expected_phase" ]; then
             echo "Phase ${expected_phase} found!"
             return 0

--- a/scripts/ci/smoke_test.sh
+++ b/scripts/ci/smoke_test.sh
@@ -31,7 +31,12 @@ checkStatusPhase() {
     endtime=$(date -ud "$runtime" +%s)
 
     while [[ $(date -u +%s) -le $endtime ]]; do
-        actual_phase=$(oc get certsuiteruns -n certsuite-operator certsuiterun-sample -o json | jq -r '.status.phase')
+        # Show the pods and the certsuiterun CR in the operator namespace
+        oc get pods -n ${CNF_CERTSUITE_OPERATOR_NAMESPACE} -o wide
+        oc get certsuiterun -n "${CNF_CERTSUITE_OPERATOR_NAMESPACE}"
+
+        # Get and check the phase of the certsuiterun CR
+        actual_phase=$(oc get certsuiteruns -n ${CNF_CERTSUITE_OPERATOR_NAMESPACE} certsuiterun-sample -o json | jq -r '.status.phase')
         if [ "$actual_phase" == "$expected_phase" ]; then
             echo "Phase ${expected_phase} found!"
             return 0

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:revive
 package utils
 
 import (


### PR DESCRIPTION
- Controller-gen moved to v0.19.0
- Openshift Console plugin CRD link updated.
- nolint comment added to the operators-sdk generated package "utils".