### PR TITLE
ci: pin golangci-lint to v2.12.1 and fix goconst findings

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -48,6 +48,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
+          version: v2.12.1
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/internal/controller/cnf-cert-job/cnfcertjob.go
+++ b/internal/controller/cnf-cert-job/cnfcertjob.go
@@ -17,6 +17,10 @@ const (
 	clusterAccessServiceAccountName = "certsuite-cluster-access"
 
 	certsuiteContainerImage = "quay.io/redhat-best-practices-for-k8s/certsuite:unstable"
+
+	volumeNameOutput              = "certsuite-output"
+	volumeNameConfig              = "certsuite-config"
+	volumeNamePreflightDockerconf = "certsuite-preflight-dockerconfig"
 )
 
 func New(options ...func(*corev1.Pod) error) (*corev1.Pod, error) {
@@ -67,7 +71,7 @@ func newInitialJobPod() *corev1.Pod {
 					ImagePullPolicy: "IfNotPresent",
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "certsuite-output",
+							Name:      volumeNameOutput,
 							ReadOnly:  true,
 							MountPath: definitions.CnfCertSuiteResultsFolder,
 						},
@@ -85,11 +89,11 @@ func newInitialJobPod() *corev1.Pod {
 					ImagePullPolicy: "Always",
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "certsuite-output",
+							Name:      volumeNameOutput,
 							MountPath: definitions.CnfCertSuiteResultsFolder,
 						},
 						{
-							Name:      "certsuite-config",
+							Name:      volumeNameConfig,
 							ReadOnly:  true,
 							MountPath: definitions.CnfCnfCertSuiteConfigFolder,
 						},
@@ -98,7 +102,7 @@ func newInitialJobPod() *corev1.Pod {
 			},
 			Volumes: []corev1.Volume{
 				{
-					Name: "certsuite-output",
+					Name: volumeNameOutput,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
@@ -171,7 +175,7 @@ func WithTimeOut(timeout string) func(*corev1.Pod) error {
 func WithConfigMap(configMapName string) func(*corev1.Pod) error {
 	return func(p *corev1.Pod) error {
 		Volume := corev1.Volume{
-			Name: "certsuite-config",
+			Name: volumeNameConfig,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -192,7 +196,7 @@ func WithPreflightSecret(preflightSecretName *string) func(*corev1.Pod) error {
 		}
 
 		Volume := corev1.Volume{
-			Name: "certsuite-preflight-dockerconfig",
+			Name: volumeNamePreflightDockerconf,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: *preflightSecretName,
@@ -203,7 +207,7 @@ func WithPreflightSecret(preflightSecretName *string) func(*corev1.Pod) error {
 
 		cnfCertCuiteContainer := getCnfCertSuiteContainer(p)
 		volumeMount := corev1.VolumeMount{
-			Name:      "certsuite-preflight-dockerconfig",
+			Name:      volumeNamePreflightDockerconf,
 			ReadOnly:  true,
 			MountPath: definitions.CnfPreflightConfigFolder,
 		}


### PR DESCRIPTION
## Summary
- Pins golangci-lint to v2.12.1 to prevent CI breakage from future releases
- Extracts repeated volume name strings (`certsuite-output`, `certsuite-config`, `certsuite-preflight-dockerconfig`) into constants to resolve goconst lint findings

## Test plan
- [ ] CI lint step passes with pinned version