### PR TITLE
docs: fix self-referencing link in README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ certsuite-operator/
 ## Development Guidelines
 
 ### Go Version
-This project uses Go 1.26.1.
+This project uses Go 1.26.
 
 ### Testing Framework
 Tests use Ginkgo/Gomega BDD framework with envtest for controller tests.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Description
 
 Kubernetes/Openshift Operator (scaffolded with operator-sdk) running the
-[Certification Suite Container](https://github.com/redhat-best-practices-for-k8s/certsuite-operator).
+[Certification Suite Container](https://github.com/redhat-best-practices-for-k8s/certsuite).
 
 The Certification Suites provide a set of test cases for the
 Containerized Network Functions/Cloud Native Functions (CNFs) to verify if


### PR DESCRIPTION
## Summary
- Fixes the project description link in README.md that pointed to certsuite-operator (itself) instead of the certsuite repo
- Corrects the Go version in AGENTS.md to match go.mod (1.26 not 1.26.1)