### PR TITLE
Set go 1.26 with toolchain go1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/redhat-best-practices-for-k8s/certsuite-operator
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary
- Set `go` directive to `1.26` (minimum version floor)
- Set `toolchain` directive to `go1.26.5` (pinned build version)
- Ran `go mod tidy`

This standardizes the Go version strategy: the `go` directive stays at the minor version, while `toolchain` pins the exact patch release used for builds.