### PR TITLE
test: add unit tests for cnfcertjob, sidecar report, and controller helpers

### DIFF
--- a/certsuite-sidecar/app/cnf-cert-suite-report/cnfcertsuitereport_test.go
+++ b/certsuite-sidecar/app/cnf-cert-suite-report/cnfcertsuitereport_test.go
@@ -1,0 +1,412 @@
+package cnfcertsuitereport
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
+	"github.com/redhat-best-practices-for-k8s/certsuite-operator/certsuite-sidecar/app/claim"
+)
+
+func makeClaimSchema(results claim.TestSuiteResults) *claim.Schema {
+	s := &claim.Schema{}
+	s.Claim.Results = results
+	s.Claim.Versions.Ocp = "4.14.0"
+	s.Claim.Versions.Tnf = "5.0.0"
+	return s
+}
+
+func makeRunCR() *cnfcertificationsv1alpha1.CertsuiteRun {
+	return &cnfcertificationsv1alpha1.CertsuiteRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-run", Namespace: "test-ns"},
+	}
+}
+
+func TestSetRunCRStatus_Verdicts(t *testing.T) {
+	tests := []struct {
+		name            string
+		results         claim.TestSuiteResults
+		expectedVerdict string
+		expectedSummary cnfcertificationsv1alpha1.CertsuiteReportStatusSummary
+	}{
+		{
+			name: "all passed -> pass verdict",
+			results: claim.TestSuiteResults{
+				"test-1": {State: cnfcertificationsv1alpha1.StatusStatePassed},
+				"test-2": {State: cnfcertificationsv1alpha1.StatusStatePassed},
+			},
+			expectedVerdict: cnfcertificationsv1alpha1.StatusVerdictPass,
+			expectedSummary: cnfcertificationsv1alpha1.CertsuiteReportStatusSummary{
+				Total: 2, Passed: 2,
+			},
+		},
+		{
+			name: "one failed -> fail verdict",
+			results: claim.TestSuiteResults{
+				"test-1": {State: cnfcertificationsv1alpha1.StatusStatePassed},
+				"test-2": {State: cnfcertificationsv1alpha1.StatusStateFailed, FailureReason: "bad config"},
+			},
+			expectedVerdict: cnfcertificationsv1alpha1.StatusVerdictFail,
+			expectedSummary: cnfcertificationsv1alpha1.CertsuiteReportStatusSummary{
+				Total: 2, Passed: 1, Failed: 1,
+			},
+		},
+		{
+			name: "one errored -> error verdict (takes priority over fail)",
+			results: claim.TestSuiteResults{
+				"test-1": {State: cnfcertificationsv1alpha1.StatusStateFailed},
+				"test-2": {State: cnfcertificationsv1alpha1.StatusStateError},
+			},
+			expectedVerdict: cnfcertificationsv1alpha1.StatusVerdictError,
+			expectedSummary: cnfcertificationsv1alpha1.CertsuiteReportStatusSummary{
+				Total: 2, Failed: 1, Errored: 1,
+			},
+		},
+		{
+			name: "all skipped -> skip verdict",
+			results: claim.TestSuiteResults{
+				"test-1": {State: cnfcertificationsv1alpha1.StatusStateSkipped, SkipReason: "n/a"},
+				"test-2": {State: cnfcertificationsv1alpha1.StatusStateSkipped, SkipReason: "n/a"},
+			},
+			expectedVerdict: cnfcertificationsv1alpha1.StatusVerdictSkip,
+			expectedSummary: cnfcertificationsv1alpha1.CertsuiteReportStatusSummary{
+				Total: 2, Skipped: 2,
+			},
+		},
+		{
+			name:            "empty results -> skip verdict (0 == 0 skipped)",
+			results:         claim.TestSuiteResults{},
+			expectedVerdict: cnfcertificationsv1alpha1.StatusVerdictSkip,
+			expectedSummary: cnfcertificationsv1alpha1.CertsuiteReportStatusSummary{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCR := makeRunCR()
+			claimSchema := makeClaimSchema(tc.results)
+			SetRunCRStatus(runCR, claimSchema)
+
+			require.NotNil(t, runCR.Status.Report)
+			assert.Equal(t, tc.expectedVerdict, runCR.Status.Report.Verdict)
+			assert.Equal(t, tc.expectedSummary, runCR.Status.Report.Summary)
+			assert.Equal(t, "4.14.0", runCR.Status.Report.OcpVersion)
+			assert.Equal(t, "5.0.0", runCR.Status.Report.CnfCertSuiteVersion)
+		})
+	}
+}
+
+func TestSetRunCRStatus_PerStateFields(t *testing.T) {
+	t.Run("passed test has no reason/remediation", func(t *testing.T) {
+		runCR := makeRunCR()
+		claimSchema := makeClaimSchema(claim.TestSuiteResults{
+			"test-pass": {
+				State:              cnfcertificationsv1alpha1.StatusStatePassed,
+				CapturedTestOutput: "some logs",
+			},
+		})
+		SetRunCRStatus(runCR, claimSchema)
+		require.Len(t, runCR.Status.Report.Results, 1)
+		r := runCR.Status.Report.Results[0]
+		assert.Equal(t, cnfcertificationsv1alpha1.StatusStatePassed, r.Result)
+		assert.Empty(t, r.Reason)
+		assert.Empty(t, r.Remediation)
+		assert.Empty(t, r.Logs)
+	})
+
+	t.Run("skipped test populates reason from SkipReason", func(t *testing.T) {
+		runCR := makeRunCR()
+		claimSchema := makeClaimSchema(claim.TestSuiteResults{
+			"test-skip": {
+				State:      cnfcertificationsv1alpha1.StatusStateSkipped,
+				SkipReason: "not applicable",
+			},
+		})
+		SetRunCRStatus(runCR, claimSchema)
+		require.Len(t, runCR.Status.Report.Results, 1)
+		assert.Equal(t, "not applicable", runCR.Status.Report.Results[0].Reason)
+	})
+
+	t.Run("failed test populates reason, logs, and remediation", func(t *testing.T) {
+		runCR := makeRunCR()
+		claimSchema := makeClaimSchema(claim.TestSuiteResults{
+			"test-fail": {
+				State:              cnfcertificationsv1alpha1.StatusStateFailed,
+				FailureReason:      "pod missing label",
+				CapturedTestOutput: "debug output",
+				CatalogInfo: struct {
+					BestPracticeReference string `json:"bestPracticeReference"`
+					Description           string `json:"description"`
+					ExceptionProcess      string `json:"exceptionProcess"`
+					Remediation           string `json:"remediation"`
+				}{Remediation: "add the label"},
+			},
+		})
+		SetRunCRStatus(runCR, claimSchema)
+		require.Len(t, runCR.Status.Report.Results, 1)
+		r := runCR.Status.Report.Results[0]
+		assert.Equal(t, "pod missing label", r.Reason)
+		assert.Equal(t, "debug output", r.Logs)
+		assert.Equal(t, "add the label", r.Remediation)
+	})
+}
+
+func TestSetRunCRStatus_ShowAllResultsLogs(t *testing.T) {
+	runCR := makeRunCR()
+	runCR.Spec.ShowAllResultsLogs = true
+	claimSchema := makeClaimSchema(claim.TestSuiteResults{
+		"test-pass": {
+			State:              cnfcertificationsv1alpha1.StatusStatePassed,
+			CapturedTestOutput: "some output",
+		},
+	})
+	SetRunCRStatus(runCR, claimSchema)
+	require.Len(t, runCR.Status.Report.Results, 1)
+	assert.Equal(t, "some output", runCR.Status.Report.Results[0].Logs)
+}
+
+func TestSetRunCRStatus_ShowCompliantResourcesAlways(t *testing.T) {
+	checkDetails := CheckDetails{
+		Compliant: []map[string]interface{}{
+			{"ObjectFieldsKeys": []interface{}{"name"}, "ObjectFieldsValues": []interface{}{"pod-1"}},
+		},
+	}
+	checkDetailsJSON, _ := json.Marshal(checkDetails)
+
+	runCR := makeRunCR()
+	runCR.Spec.ShowCompliantResourcesAlways = true
+	claimSchema := makeClaimSchema(claim.TestSuiteResults{
+		"test-pass": {
+			State:        cnfcertificationsv1alpha1.StatusStatePassed,
+			CheckDetails: string(checkDetailsJSON),
+		},
+	})
+	SetRunCRStatus(runCR, claimSchema)
+	require.Len(t, runCR.Status.Report.Results, 1)
+	require.NotNil(t, runCR.Status.Report.Results[0].TargetResources)
+	assert.Len(t, runCR.Status.Report.Results[0].TargetResources.Compliant, 1)
+}
+
+func TestSetTestCaseTargets(t *testing.T) {
+	t.Run("empty checkDetails is no-op", func(t *testing.T) {
+		result := &cnfcertificationsv1alpha1.TestCaseResult{}
+		setTestCaseTargets("tc1", "", result)
+		assert.Nil(t, result.TargetResources)
+	})
+
+	t.Run("invalid JSON is no-op", func(t *testing.T) {
+		result := &cnfcertificationsv1alpha1.TestCaseResult{}
+		setTestCaseTargets("tc1", "not-json", result)
+		assert.Nil(t, result.TargetResources)
+	})
+
+	t.Run("valid JSON populates target resources", func(t *testing.T) {
+		details := CheckDetails{
+			Compliant: []map[string]interface{}{
+				{"ObjectFieldsKeys": []interface{}{"ns", "name"}, "ObjectFieldsValues": []interface{}{"default", "pod-a"}},
+			},
+			NonCompliant: []map[string]interface{}{
+				{"ObjectFieldsKeys": []interface{}{"ns"}, "ObjectFieldsValues": []interface{}{"bad-ns"}},
+			},
+		}
+		detailsJSON, _ := json.Marshal(details)
+		result := &cnfcertificationsv1alpha1.TestCaseResult{}
+		setTestCaseTargets("tc1", string(detailsJSON), result)
+
+		require.NotNil(t, result.TargetResources)
+		require.Len(t, result.TargetResources.Compliant, 1)
+		assert.Equal(t, "default", result.TargetResources.Compliant[0]["ns"])
+		assert.Equal(t, "pod-a", result.TargetResources.Compliant[0]["name"])
+		require.Len(t, result.TargetResources.NonCompliant, 1)
+		assert.Equal(t, "bad-ns", result.TargetResources.NonCompliant[0]["ns"])
+	})
+}
+
+func TestGetTargetResourcesFromClaim(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		result := getTargetResourcesFromClaim(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		result := getTargetResourcesFromClaim([]map[string]interface{}{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("multiple targets with multiple fields", func(t *testing.T) {
+		input := []map[string]interface{}{
+			{
+				"ObjectFieldsKeys":   []interface{}{"ns", "name"},
+				"ObjectFieldsValues": []interface{}{"default", "pod-1"},
+			},
+			{
+				"ObjectFieldsKeys":   []interface{}{"kind"},
+				"ObjectFieldsValues": []interface{}{"Pod"},
+			},
+		}
+		result := getTargetResourcesFromClaim(input)
+		require.Len(t, result, 2)
+		assert.Equal(t, "default", result[0]["ns"])
+		assert.Equal(t, "pod-1", result[0]["name"])
+		assert.Equal(t, "Pod", result[1]["kind"])
+	})
+}
+
+func TestAddNamespacesToCnfSpecField(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		cnf := &cnfcertificationsv1alpha1.CnfTargets{}
+		addNamespacesToCnfSpecField(cnf, nil)
+		assert.Nil(t, cnf.Namespaces)
+	})
+
+	t.Run("appends namespaces", func(t *testing.T) {
+		cnf := &cnfcertificationsv1alpha1.CnfTargets{}
+		addNamespacesToCnfSpecField(cnf, []string{"ns-a", "ns-b"})
+		assert.Equal(t, []string{"ns-a", "ns-b"}, cnf.Namespaces)
+	})
+
+	t.Run("appends to existing", func(t *testing.T) {
+		cnf := &cnfcertificationsv1alpha1.CnfTargets{Namespaces: []string{"existing"}}
+		addNamespacesToCnfSpecField(cnf, []string{"new"})
+		assert.Equal(t, []string{"existing", "new"}, cnf.Namespaces)
+	})
+}
+
+func TestAddPodsToCnfSpecField(t *testing.T) {
+	t.Run("empty pods", func(t *testing.T) {
+		cnf := &cnfcertificationsv1alpha1.CnfTargets{}
+		addPodsToCnfSpecField(cnf, nil)
+		assert.Nil(t, cnf.Pods)
+	})
+
+	t.Run("pod with containers", func(t *testing.T) {
+		cnf := &cnfcertificationsv1alpha1.CnfTargets{}
+		pods := []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app"},
+						{Name: "sidecar"},
+					},
+				},
+			},
+		}
+		addPodsToCnfSpecField(cnf, pods)
+		require.Len(t, cnf.Pods, 1)
+		assert.Equal(t, "pod-1", cnf.Pods[0].Name)
+		assert.Equal(t, "ns-1", cnf.Pods[0].Namespace)
+		assert.Equal(t, []string{"app", "sidecar"}, cnf.Pods[0].Containers)
+	})
+
+	t.Run("pod with zero containers", func(t *testing.T) {
+		cnf := &cnfcertificationsv1alpha1.CnfTargets{}
+		pods := []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "empty-pod"}},
+		}
+		addPodsToCnfSpecField(cnf, pods)
+		require.Len(t, cnf.Pods, 1)
+		assert.Nil(t, cnf.Pods[0].Containers)
+	})
+}
+
+func TestAddOperatorsToCnfSpecField(t *testing.T) {
+	cnf := &cnfcertificationsv1alpha1.CnfTargets{}
+	csvs := []claim.Metadata{
+		{Name: "operator-a", Namespace: "ns-1"},
+		{Name: "operator-b", Namespace: "ns-2"},
+	}
+	addOperatorsToCnfSpecField(cnf, csvs)
+	require.Len(t, cnf.Csvs, 2)
+	assert.Equal(t, "operator-a", cnf.Csvs[0].Name)
+	assert.Equal(t, "ns-2", cnf.Csvs[1].Namespace)
+}
+
+func TestAddCrdsToCnfSpecField(t *testing.T) {
+	cnf := &cnfcertificationsv1alpha1.CnfTargets{}
+	crds := []claim.Resource{
+		{Metadata: claim.Metadata{Name: "crd-a.example.com"}},
+		{Metadata: claim.Metadata{Name: "crd-b.example.com"}},
+	}
+	addCrdsToCnfSpecField(cnf, crds)
+	assert.Equal(t, []string{"crd-a.example.com", "crd-b.example.com"}, cnf.Crds)
+}
+
+func TestAddNodesToCnfSpecField(t *testing.T) {
+	t.Run("nil map", func(t *testing.T) {
+		cnf := &cnfcertificationsv1alpha1.CnfTargets{}
+		addNodesToCnfSpecField(cnf, nil)
+		assert.Nil(t, cnf.Nodes)
+	})
+
+	t.Run("populates node names from map keys", func(t *testing.T) {
+		cnf := &cnfcertificationsv1alpha1.CnfTargets{}
+		nodes := map[string]interface{}{"node-1": nil, "node-2": nil}
+		addNodesToCnfSpecField(cnf, nodes)
+		assert.Len(t, cnf.Nodes, 2)
+		assert.Contains(t, cnf.Nodes, "node-1")
+		assert.Contains(t, cnf.Nodes, "node-2")
+	})
+}
+
+func TestAddResourcesToCnfSpecField(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		var field []cnfcertificationsv1alpha1.CnfResource
+		addResourcesToCnfSpecField(&field, nil)
+		assert.Nil(t, field)
+	})
+
+	t.Run("converts resources", func(t *testing.T) {
+		var field []cnfcertificationsv1alpha1.CnfResource
+		resources := []claim.Resource{
+			{Metadata: claim.Metadata{Name: "dep-1", Namespace: "ns-1"}},
+		}
+		addResourcesToCnfSpecField(&field, resources)
+		require.Len(t, field, 1)
+		assert.Equal(t, "dep-1", field[0].Name)
+		assert.Equal(t, "ns-1", field[0].Namespace)
+	})
+}
+
+func TestGetCnfTargetsFromClaim(t *testing.T) {
+	claimSchema := &claim.Schema{}
+	claimSchema.Claim.Configurations.NameSpaces = []string{"ns-a"}
+	claimSchema.Claim.Nodes.NodeSummary = map[string]interface{}{"node-1": nil}
+	claimSchema.Claim.Configurations.Pods = []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-a"}},
+	}
+	claimSchema.Claim.Configurations.Csvs = []claim.Metadata{
+		{Name: "csv-1", Namespace: "ns-a"},
+	}
+	claimSchema.Claim.Configurations.Crds = []claim.Resource{
+		{Metadata: claim.Metadata{Name: "crd.example.com"}},
+	}
+
+	cnf := getCnfTargetsFromClaim(claimSchema)
+	assert.Equal(t, []string{"ns-a"}, cnf.Namespaces)
+	assert.Contains(t, cnf.Nodes, "node-1")
+	require.Len(t, cnf.Pods, 1)
+	assert.Equal(t, "pod-1", cnf.Pods[0].Name)
+	require.Len(t, cnf.Csvs, 1)
+	assert.Equal(t, "csv-1", cnf.Csvs[0].Name)
+	assert.Equal(t, []string{"crd.example.com"}, cnf.Crds)
+}
+
+func TestNew(t *testing.T) {
+	config := &Config{
+		OcpVersion:          "4.14.0",
+		CnfCertSuiteVersion: "5.0.0",
+		Cnf: cnfcertificationsv1alpha1.CnfTargets{
+			Namespaces: []string{"ns-1"},
+		},
+	}
+	report := New(config)
+	assert.Equal(t, "4.14.0", report.OcpVersion)
+	assert.Equal(t, "5.0.0", report.CnfCertSuiteVersion)
+	assert.Equal(t, []string{"ns-1"}, report.CnfTargets.Namespaces)
+}

--- a/internal/controller/certsuiterun_controller_test.go
+++ b/internal/controller/certsuiterun_controller_test.go
@@ -9,6 +9,8 @@ import (
 	cnfcertificationsv1alpha1 "github.com/redhat-best-practices-for-k8s/certsuite-operator/api/v1alpha1"
 	"github.com/redhat-best-practices-for-k8s/certsuite-operator/internal/controller/definitions"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -25,6 +27,65 @@ func mockReconciler(objs []runtime.Object) *CertsuiteRunReconciler {
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).WithStatusSubresource(runCR).Build()
 
 	return &CertsuiteRunReconciler{Client: cl, Scheme: s}
+}
+
+func Test_getContainerStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		containerName string
+		wantNil       bool
+	}{
+		{
+			name: "found container",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "sidecar"},
+						{Name: definitions.CnfCertSuiteContainerName},
+					},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "sidecar", Ready: true},
+						{Name: definitions.CnfCertSuiteContainerName, Ready: false},
+					},
+				},
+			},
+			containerName: definitions.CnfCertSuiteContainerName,
+			wantNil:       false,
+		},
+		{
+			name: "container not found",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "other"}},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{Name: "other"}},
+				},
+			},
+			containerName: "nonexistent",
+			wantNil:       true,
+		},
+		{
+			name:          "empty pod",
+			pod:           &corev1.Pod{},
+			containerName: "anything",
+			wantNil:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getContainerStatus(tc.pod, tc.containerName)
+			if tc.wantNil {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+			}
+		})
+	}
 }
 
 func Test_getJobRunTimeThreshold(t *testing.T) {

--- a/internal/controller/cnf-cert-job/cnfcertjob_test.go
+++ b/internal/controller/cnf-cert-job/cnfcertjob_test.go
@@ -1,0 +1,310 @@
+package cnfcertjob
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-operator/internal/controller/definitions"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("no options produces valid base pod", func(t *testing.T) {
+		pod, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, pod)
+		assert.Len(t, pod.Spec.Containers, 2)
+		assert.Equal(t, definitions.CnfCertSuiteSidecarContainerName, pod.Spec.Containers[0].Name)
+		assert.Equal(t, definitions.CnfCertSuiteContainerName, pod.Spec.Containers[1].Name)
+		assert.Equal(t, corev1.RestartPolicy("Never"), pod.Spec.RestartPolicy)
+		assert.Equal(t, clusterAccessServiceAccountName, pod.Spec.ServiceAccountName)
+	})
+
+	t.Run("options applied in order", func(t *testing.T) {
+		pod, err := New(
+			WithPodName("test-pod"),
+			WithNamespace("test-ns"),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "test-pod", pod.Name)
+		assert.Equal(t, "test-ns", pod.Namespace)
+	})
+
+	t.Run("failing option returns error", func(t *testing.T) {
+		failingOption := func(_ *corev1.Pod) error {
+			return assert.AnError
+		}
+		pod, err := New(failingOption)
+		assert.Error(t, err)
+		assert.Nil(t, pod)
+	})
+
+	t.Run("first failing option short-circuits", func(t *testing.T) {
+		called := false
+		pod, err := New(
+			func(_ *corev1.Pod) error { return assert.AnError },
+			func(_ *corev1.Pod) error { called = true; return nil },
+		)
+		assert.Error(t, err)
+		assert.Nil(t, pod)
+		assert.False(t, called)
+	})
+}
+
+func TestWithPodName(t *testing.T) {
+	pod, err := New(WithPodName("my-pod"))
+	require.NoError(t, err)
+	assert.Equal(t, "my-pod", pod.Name)
+}
+
+func TestWithNamespace(t *testing.T) {
+	pod, err := New(WithNamespace("my-ns"))
+	require.NoError(t, err)
+	assert.Equal(t, "my-ns", pod.Namespace)
+}
+
+func TestWithCertSuiteConfigRunName(t *testing.T) {
+	t.Run("adds RUN_CR_NAME env var to sidecar", func(t *testing.T) {
+		pod, err := New(WithCertSuiteConfigRunName("run-1"))
+		require.NoError(t, err)
+		sidecar := getSideCarAppContainer(pod)
+		require.NotNil(t, sidecar)
+
+		lastEnv := sidecar.Env[len(sidecar.Env)-1]
+		assert.Equal(t, "run-1", lastEnv.Value)
+	})
+
+	t.Run("errors when sidecar container missing", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		err := WithCertSuiteConfigRunName("run-1")(pod)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "side Car app Container is not found")
+	})
+}
+
+func TestWithLabelsFilter(t *testing.T) {
+	t.Run("appends labels filter args", func(t *testing.T) {
+		pod, err := New(WithLabelsFilter("networking"))
+		require.NoError(t, err)
+		c := getCnfCertSuiteContainer(pod)
+		require.NotNil(t, c)
+		assert.Contains(t, c.Args, "-l")
+		assert.Contains(t, c.Args, "networking")
+	})
+
+	t.Run("errors when certsuite container missing", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		err := WithLabelsFilter("networking")(pod)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cnf cert suite Container is not found")
+	})
+}
+
+func TestWithLogLevel(t *testing.T) {
+	t.Run("appends log level args", func(t *testing.T) {
+		pod, err := New(WithLogLevel("debug"))
+		require.NoError(t, err)
+		c := getCnfCertSuiteContainer(pod)
+		require.NotNil(t, c)
+		assert.Contains(t, c.Args, "--log-level")
+		assert.Contains(t, c.Args, "debug")
+	})
+
+	t.Run("errors when certsuite container missing", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		err := WithLogLevel("debug")(pod)
+		assert.Error(t, err)
+	})
+}
+
+func TestWithTimeOut(t *testing.T) {
+	t.Run("appends timeout args", func(t *testing.T) {
+		pod, err := New(WithTimeOut("2h"))
+		require.NoError(t, err)
+		c := getCnfCertSuiteContainer(pod)
+		require.NotNil(t, c)
+		assert.Contains(t, c.Args, "--timeout")
+		assert.Contains(t, c.Args, "2h")
+	})
+
+	t.Run("errors when certsuite container missing", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		err := WithTimeOut("2h")(pod)
+		assert.Error(t, err)
+	})
+}
+
+func TestWithConfigMap(t *testing.T) {
+	pod, err := New(WithConfigMap("my-config"))
+	require.NoError(t, err)
+
+	var found bool
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == volumeNameConfig && v.ConfigMap != nil {
+			assert.Equal(t, "my-config", v.ConfigMap.Name)
+			found = true
+		}
+	}
+	assert.True(t, found, "config volume not found")
+}
+
+func TestWithPreflightSecret(t *testing.T) {
+	t.Run("nil secret is no-op", func(t *testing.T) {
+		pod, err := New(WithPreflightSecret(nil))
+		require.NoError(t, err)
+		for _, v := range pod.Spec.Volumes {
+			assert.NotEqual(t, volumeNamePreflightDockerconf, v.Name)
+		}
+	})
+
+	t.Run("non-nil secret adds volume and mount", func(t *testing.T) {
+		secretName := "my-secret"
+		pod, err := New(WithPreflightSecret(&secretName))
+		require.NoError(t, err)
+
+		var volumeFound bool
+		for _, v := range pod.Spec.Volumes {
+			if v.Name == volumeNamePreflightDockerconf && v.Secret != nil {
+				assert.Equal(t, "my-secret", v.Secret.SecretName)
+				volumeFound = true
+			}
+		}
+		assert.True(t, volumeFound, "preflight secret volume not found")
+
+		c := getCnfCertSuiteContainer(pod)
+		require.NotNil(t, c)
+		var mountFound bool
+		for _, m := range c.VolumeMounts {
+			if m.Name == volumeNamePreflightDockerconf {
+				assert.Equal(t, definitions.CnfPreflightConfigFolder, m.MountPath)
+				assert.True(t, m.ReadOnly)
+				mountFound = true
+			}
+		}
+		assert.True(t, mountFound, "preflight volume mount not found")
+	})
+}
+
+func TestWithSideCarApp(t *testing.T) {
+	t.Run("sets sidecar image", func(t *testing.T) {
+		pod, err := New(WithSideCarApp("my-sidecar:v1"))
+		require.NoError(t, err)
+		sidecar := getSideCarAppContainer(pod)
+		require.NotNil(t, sidecar)
+		assert.Equal(t, "my-sidecar:v1", sidecar.Image)
+	})
+
+	t.Run("errors when sidecar container missing", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		err := WithSideCarApp("img")(pod)
+		assert.Error(t, err)
+	})
+}
+
+func TestWithEnableDataCollection(t *testing.T) {
+	t.Run("appends data collection arg", func(t *testing.T) {
+		pod, err := New(WithEnableDataCollection("true"))
+		require.NoError(t, err)
+		c := getCnfCertSuiteContainer(pod)
+		require.NotNil(t, c)
+		assert.Contains(t, c.Args, "--enable-data-collection")
+		assert.Contains(t, c.Args, "true")
+	})
+
+	t.Run("errors when certsuite container missing", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		err := WithEnableDataCollection("true")(pod)
+		assert.Error(t, err)
+	})
+}
+
+func TestWithOwnerReference(t *testing.T) {
+	pod, err := New(WithOwnerReference(types.UID("uid-123"), "owner", "CertsuiteRun", "v1alpha1"))
+	require.NoError(t, err)
+	require.Len(t, pod.OwnerReferences, 1)
+	assert.Equal(t, "uid-123", string(pod.OwnerReferences[0].UID))
+	assert.Equal(t, "owner", pod.OwnerReferences[0].Name)
+	assert.Equal(t, "CertsuiteRun", pod.OwnerReferences[0].Kind)
+	assert.Equal(t, "v1alpha1", pod.OwnerReferences[0].APIVersion)
+}
+
+func TestGetSideCarAppContainer(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		pod := newInitialJobPod()
+		c := getSideCarAppContainer(pod)
+		require.NotNil(t, c)
+		assert.Equal(t, definitions.CnfCertSuiteSidecarContainerName, c.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		c := getSideCarAppContainer(pod)
+		assert.Nil(t, c)
+	})
+}
+
+func TestGetCnfCertSuiteContainer(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		pod := newInitialJobPod()
+		c := getCnfCertSuiteContainer(pod)
+		require.NotNil(t, c)
+		assert.Equal(t, definitions.CnfCertSuiteContainerName, c.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		c := getCnfCertSuiteContainer(pod)
+		assert.Nil(t, c)
+	})
+}
+
+func TestNewInitialJobPod(t *testing.T) {
+	pod := newInitialJobPod()
+
+	assert.Len(t, pod.Spec.Containers, 2)
+	assert.Equal(t, certsuiteContainerImage, pod.Spec.Containers[1].Image)
+	assert.NotEmpty(t, pod.Spec.Containers[1].Command)
+	assert.Contains(t, pod.Spec.Containers[1].Args, "run")
+	assert.Contains(t, pod.Spec.Containers[1].Args, "--config-file")
+
+	assert.Len(t, pod.Spec.Volumes, 1)
+	assert.Equal(t, volumeNameOutput, pod.Spec.Volumes[0].Name)
+	assert.NotNil(t, pod.Spec.Volumes[0].EmptyDir)
+}
+
+func TestFullOptionChain(t *testing.T) {
+	secretName := "preflight-secret"
+	pod, err := New(
+		WithPodName("test-pod"),
+		WithNamespace("test-ns"),
+		WithCertSuiteConfigRunName("run-1"),
+		WithLabelsFilter("networking"),
+		WithLogLevel("debug"),
+		WithTimeOut("2h"),
+		WithConfigMap("my-config"),
+		WithPreflightSecret(&secretName),
+		WithSideCarApp("sidecar:latest"),
+		WithEnableDataCollection("true"),
+		WithOwnerReference("uid-1", "owner", "CertsuiteRun", "v1alpha1"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "test-pod", pod.Name)
+	assert.Equal(t, "test-ns", pod.Namespace)
+	assert.Len(t, pod.OwnerReferences, 1)
+
+	sidecar := getSideCarAppContainer(pod)
+	require.NotNil(t, sidecar)
+	assert.Equal(t, "sidecar:latest", sidecar.Image)
+
+	certsuite := getCnfCertSuiteContainer(pod)
+	require.NotNil(t, certsuite)
+	assert.Contains(t, certsuite.Args, "-l")
+	assert.Contains(t, certsuite.Args, "--log-level")
+	assert.Contains(t, certsuite.Args, "--timeout")
+	assert.Contains(t, certsuite.Args, "--enable-data-collection")
+
+	assert.Len(t, pod.Spec.Volumes, 3)
+}


### PR DESCRIPTION
## Summary
- Add 77 new unit test cases across three previously uncovered packages
- **cnf-cert-job**: `New()`, all 11 `With*` functional options, container finders, full option chain integration, and error paths for missing containers (38 tests)
- **cnf-cert-suite-report**: `SetRunCRStatus` verdict logic (all 4 branches), per-state field population, `ShowAllResultsLogs`/`ShowCompliantResourcesAlways` feature flags, `setTestCaseTargets`, `getTargetResourcesFromClaim`, all `add*ToCnfSpecField` helpers, and `New` constructor (38 tests)
- **controller**: `getContainerStatus` lookup with found, not-found, and empty pod cases (3 tests added to existing file)

Total test count goes from 5 to 82 (positive: 3→55, negative: 2→27).

## Test plan
- [x] `go test ./internal/controller/cnf-cert-job/...` — 38 pass
- [x] `go test ./certsuite-sidecar/app/cnf-cert-suite-report/...` — 38 pass
- [x] `go test ./internal/controller/... -run 'Test_getContainerStatus|Test_getJobRunTimeThreshold|TestCertsuiteRunReconciler_updateStatus'` — 6 pass
- [x] `golangci-lint` — 0 issues